### PR TITLE
CODE-175 convert basic chai suites to jest matchers

### DIFF
--- a/topics/js/lessons/02-Conditionals/tests/01-logicallySpeaking.test.js
+++ b/topics/js/lessons/02-Conditionals/tests/01-logicallySpeaking.test.js
@@ -6,44 +6,43 @@ import { andTrue, andFalse, orTrue, orFalse } from "../index.js";
  * To test your answers to one of the problems above:
  * 1. Find the number of the problem you're working on
  * 2. Remove the `x` in `xdescribe` so that it reads `describe`
- * 3. Type `npm run test-02` in the Shell and hit Enter.
+ * 3. Type `npm run test:02` in the Shell and hit Enter.
  */
-import { expect } from "chai";
 
 describe("#1: Logically speaking", () => {
   describe("Using the && (AND) operator", () => {
     it("andTrue -> is defined", () => {
-      expect(andTrue).not.to.be.undefined;
+      expect(andTrue).not.toBeUndefined();
     });
 
     it("andTrue -> evaluates two givens with && to TRUE", () => {
-      expect(andTrue).to.be.true;
+      expect(andTrue).toBe(true);
     });
 
     it("andFalse -> is defined", () => {
-      expect(andFalse).not.to.be.undefined;
+      expect(andFalse).not.toBeUndefined();
     });
 
     it("andFalse -> evaluates two givens with && to FALSE", () => {
-      expect(andFalse).to.be.false;
+      expect(andFalse).toBe(false);
     });
   });
 
   describe("Using the || (OR) operator", () => {
     it("orTrue -> is defined", () => {
-      expect(orTrue).not.to.be.undefined;
+      expect(orTrue).not.toBeUndefined();
     });
 
     it("orTrue -> evaluates two givens with || to TRUE", () => {
-      expect(orTrue).to.be.true;
+      expect(orTrue).toBe(true);
     });
 
     it("orFalse -> is defined", () => {
-      expect(orFalse).not.to.be.undefined;
+      expect(orFalse).not.toBeUndefined();
     });
 
     it("orFalse -> evaluates two givens with || to FALSE", () => {
-      expect(orFalse).to.be.false;
+      expect(orFalse).toBe(false);
     });
   });
 });

--- a/topics/js/lessons/02-Conditionals/tests/02-fiveCharacters.test.js
+++ b/topics/js/lessons/02-Conditionals/tests/02-fiveCharacters.test.js
@@ -1,24 +1,24 @@
-import { expect } from "chai";
 import { notFiveChars, isItFiveChars } from "../index.js";
 
 describe("#2: 5 characters", () => {
   describe("notFiveChars", () => {
     it("is defined", () => {
-      expect(notFiveChars).not.to.be.undefined;
+      expect(notFiveChars).not.toBeUndefined();
     });
 
     it("is a string that isn't 5 characters long", () => {
-      expect(notFiveChars).to.be.a("string").to.not.have.lengthOf(5);
+      expect(typeof notFiveChars).toBe("string");
+      expect(notFiveChars).not.toHaveLength(5);
     });
   });
 
   describe("isItFiveChars", () => {
     it("is defined", () => {
-      expect(isItFiveChars).not.to.be.undefined;
+      expect(isItFiveChars).not.toBeUndefined();
     });
 
     it("resolves to the String `it's 5 characters`", () => {
-      expect(isItFiveChars).to.equal("not 5 characters");
+      expect(isItFiveChars).toBe("not 5 characters");
     });
   });
 });

--- a/topics/js/lessons/02-Conditionals/tests/03-numberOrString.test.js
+++ b/topics/js/lessons/02-Conditionals/tests/03-numberOrString.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { numberOrString } from "../index.js";
 
 /**
@@ -7,23 +6,23 @@ import { numberOrString } from "../index.js";
  * To test your answers to one of the problems above:
  * 1. Find the number of the problem you're working on
  * 2. Remove the `x` in `xdescribe` so that it reads `describe`
- * 3. Type `npm run test-02` in the Shell and hit Enter.
+ * 3. Type `npm run test:02` in the Shell and hit Enter.
  */
 
 describe("#3: numberOrString", () => {
   describe("returns the correct output", () => {
     it("string input -> 'This is a string'", () => {
-      expect(numberOrString("")).to.equal("This is a string");
-      expect(numberOrString("a")).to.equal("This is a string");
-      expect(numberOrString("word")).to.equal("This is a string");
-      expect(numberOrString("two words")).to.equal("This is a string");
-      expect(numberOrString("a1b2c3")).to.equal("This is a string");
+      expect(numberOrString("")).toBe("This is a string");
+      expect(numberOrString("a")).toBe("This is a string");
+      expect(numberOrString("word")).toBe("This is a string");
+      expect(numberOrString("two words")).toBe("This is a string");
+      expect(numberOrString("a1b2c3")).toBe("This is a string");
     });
 
     it("number input -> 'This is a number'", () => {
       for (let i = 1; i <= 100; i++) {
         let num = i * Math.ceil(Math.random() * 99);
-        expect(numberOrString(num)).to.equal("This is a number");
+        expect(numberOrString(num)).toBe("This is a number");
       }
     });
 
@@ -31,7 +30,7 @@ describe("#3: numberOrString", () => {
       let types = [{ a: 1 }, [1, 2, 3], false];
 
       types.forEach((type) => {
-        expect(numberOrString(type)).to.be.a("string");
+        expect(typeof numberOrString(type)).toBe("string");
       });
     });
   });

--- a/topics/js/lessons/02-Conditionals/tests/04-truthyFalsy.test.js
+++ b/topics/js/lessons/02-Conditionals/tests/04-truthyFalsy.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { truthyFalsy } from "../index.js";
 
 /**
@@ -7,54 +6,54 @@ import { truthyFalsy } from "../index.js";
  * To test your answers to one of the problems above:
  * 1. Find the number of the problem you're working on
  * 2. Remove the `x` in `xdescribe` so that it reads `describe`
- * 3. Type `npm run test-02` in the Shell and hit Enter.
+ * 3. Type `npm run test:02` in the Shell and hit Enter.
  */
 
 describe("#4: truthyFalsy", () => {
   describe("returns false", () => {
     it("value -> 0", () => {
-      expect(truthyFalsy(0)).to.be.false;
+      expect(truthyFalsy(0)).toBe(false);
     });
 
     it('value -> ""', () => {
-      expect(truthyFalsy("")).to.be.false;
+      expect(truthyFalsy("")).toBe(false);
     });
 
     it("value -> null", () => {
-      expect(truthyFalsy(null)).to.be.false;
+      expect(truthyFalsy(null)).toBe(false);
     });
 
     it("value -> undefined", () => {
-      expect(truthyFalsy(undefined)).to.be.false;
+      expect(truthyFalsy(undefined)).toBe(false);
     });
   });
 
   describe("returns true", () => {
     it("value -> false", () => {
-      expect(truthyFalsy(false)).to.be.false;
+      expect(truthyFalsy(false)).toBe(false);
     });
 
     it("value -> any other number", () => {
-      expect(truthyFalsy(1)).to.be.true;
-      expect(truthyFalsy(Math.PI)).to.be.true;
-      expect(truthyFalsy(Infinity)).to.be.true;
+      expect(truthyFalsy(1)).toBe(true);
+      expect(truthyFalsy(Math.PI)).toBe(true);
+      expect(truthyFalsy(Infinity)).toBe(true);
     });
 
     it("value -> any other string", () => {
-      expect(truthyFalsy("a")).to.be.true;
-      expect(truthyFalsy("hello 'world'")).to.be.true;
-      expect(truthyFalsy(`template expression 1 + 2 = ${1 + 2}`)).to.be.true;
+      expect(truthyFalsy("a")).toBe(true);
+      expect(truthyFalsy("hello 'world'")).toBe(true);
+      expect(truthyFalsy(`template expression 1 + 2 = ${1 + 2}`)).toBe(true);
     });
 
     it("value -> an array", () => {
-      expect(truthyFalsy([])).to.be.true;
-      expect(truthyFalsy([1])).to.be.true;
-      expect(truthyFalsy([1, 2, 3, 4, 5])).to.be.true;
+      expect(truthyFalsy([])).toBe(true);
+      expect(truthyFalsy([1])).toBe(true);
+      expect(truthyFalsy([1, 2, 3, 4, 5])).toBe(true);
     });
 
     it("value -> an object", () => {
-      expect(truthyFalsy({})).to.be.true;
-      expect(truthyFalsy({ a: 1 })).to.be.true;
+      expect(truthyFalsy({})).toBe(true);
+      expect(truthyFalsy({ a: 1 })).toBe(true);
     });
   });
 });

--- a/topics/js/lessons/02-Conditionals/tests/05-letsGoParty.test.js
+++ b/topics/js/lessons/02-Conditionals/tests/05-letsGoParty.test.js
@@ -1,5 +1,4 @@
 import { letsGoParty } from "../index.js";
-import { expect } from "chai";
 
 describe("#5: letsGoParty", () => {
   const validAge = 32;
@@ -14,19 +13,19 @@ describe("#5: letsGoParty", () => {
 
   describe("rejects person if just one condition fails", () => {
     it("legalAge less than 25", () => {
-      expect(letsGoParty(invalidAge, validOutfit, validCover)).to.equal(
+      expect(letsGoParty(invalidAge, validOutfit, validCover)).toBe(
         invalidResult
       );
     });
 
     it("outfitType is not correct", () => {
-      expect(letsGoParty(validAge, invalidOutfit, validCover)).to.equal(
+      expect(letsGoParty(validAge, invalidOutfit, validCover)).toBe(
         invalidResult
       );
     });
 
     it("doesn't have the money to pay the cover charge", () => {
-      expect(letsGoParty(validAge, validOutfit, invalidCover)).to.equal(
+      expect(letsGoParty(validAge, validOutfit, invalidCover)).toBe(
         invalidResult
       );
     });
@@ -34,19 +33,19 @@ describe("#5: letsGoParty", () => {
 
   describe("rejects person if two conditions fail", () => {
     it("age + outfit", () => {
-      expect(letsGoParty(invalidAge, invalidOutfit, validCover)).to.equal(
+      expect(letsGoParty(invalidAge, invalidOutfit, validCover)).toBe(
         invalidResult
       );
     });
 
     it("age + cover", () => {
-      expect(letsGoParty(invalidAge, invalidOutfit, validCover)).to.equal(
+      expect(letsGoParty(invalidAge, invalidOutfit, validCover)).toBe(
         invalidResult
       );
     });
 
     it("outfit + cover", () => {
-      expect(letsGoParty(validAge, invalidOutfit, invalidCover)).to.equal(
+      expect(letsGoParty(validAge, invalidOutfit, invalidCover)).toBe(
         invalidResult
       );
     });
@@ -54,14 +53,14 @@ describe("#5: letsGoParty", () => {
 
   describe("rejects person if all three conditions fail", () => {
     it("age + outfit + cover", () => {
-      expect(letsGoParty(invalidAge, invalidOutfit, invalidCover)).to.equal(
+      expect(letsGoParty(invalidAge, invalidOutfit, invalidCover)).toBe(
         invalidResult
       );
     });
   });
 
   it("lets a person party if they pass all three conditions", () => {
-    expect(letsGoParty(25, validOutfit, validCover)).to.equal(validResult);
-    expect(letsGoParty(50, validOutfit, validCover)).to.equal(validResult);
+    expect(letsGoParty(25, validOutfit, validCover)).toBe(validResult);
+    expect(letsGoParty(50, validOutfit, validCover)).toBe(validResult);
   });
 });

--- a/topics/js/lessons/02-Conditionals/tests/06-testGrader.test.js
+++ b/topics/js/lessons/02-Conditionals/tests/06-testGrader.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { testGrader } from "../index.js";
 
 /**
@@ -7,43 +6,43 @@ import { testGrader } from "../index.js";
  * To test your answers to one of the problems above:
  * 1. Find the number of the problem you're working on
  * 2. Remove the `x` in `xdescribe` so that it reads `describe`
- * 3. Type `npm run test-02` in the Shell and hit Enter.
+ * 3. Type `npm run test:02` in the Shell and hit Enter.
  */
 
 describe("#6: testGrader", () => {
   describe("returns the correct grade", () => {
     it("when grade is between 90 and 100", () => {
-      expect(testGrader(100)).to.equal("A");
-      expect(testGrader(97)).to.equal("A");
-      expect(testGrader(93)).to.equal("A");
-      expect(testGrader(90)).to.equal("A");
+      expect(testGrader(100)).toBe("A");
+      expect(testGrader(97)).toBe("A");
+      expect(testGrader(93)).toBe("A");
+      expect(testGrader(90)).toBe("A");
     });
 
     it("when grade is between 80 and 89", () => {
-      expect(testGrader(89)).to.equal("B");
-      expect(testGrader(87)).to.equal("B");
-      expect(testGrader(83)).to.equal("B");
-      expect(testGrader(80)).to.equal("B");
+      expect(testGrader(89)).toBe("B");
+      expect(testGrader(87)).toBe("B");
+      expect(testGrader(83)).toBe("B");
+      expect(testGrader(80)).toBe("B");
     });
 
     it("when grade is between 70 and 79", () => {
-      expect(testGrader(79)).to.equal("C");
-      expect(testGrader(77)).to.equal("C");
-      expect(testGrader(73)).to.equal("C");
-      expect(testGrader(70)).to.equal("C");
+      expect(testGrader(79)).toBe("C");
+      expect(testGrader(77)).toBe("C");
+      expect(testGrader(73)).toBe("C");
+      expect(testGrader(70)).toBe("C");
     });
 
     it("when grade is between 60 and 69", () => {
-      expect(testGrader(69)).to.equal("D");
-      expect(testGrader(67)).to.equal("D");
-      expect(testGrader(63)).to.equal("D");
-      expect(testGrader(60)).to.equal("D");
+      expect(testGrader(69)).toBe("D");
+      expect(testGrader(67)).toBe("D");
+      expect(testGrader(63)).toBe("D");
+      expect(testGrader(60)).toBe("D");
     });
 
     it("when grade is between 0 and 60", () => {
       for (let i = 0; i < 60; i++) {
         let gradeUnder60 = Math.ceil(Math.random() * 59);
-        expect(testGrader(gradeUnder60)).to.equal("F");
+        expect(testGrader(gradeUnder60)).toBe("F");
       }
     });
   });
@@ -52,19 +51,19 @@ describe("#6: testGrader", () => {
     const err = "Not a valid grade.";
 
     it("invalid numbers", () => {
-      expect(testGrader(-12)).to.equal(err);
-      expect(testGrader(-1)).to.equal(err);
-      expect(testGrader(101)).to.equal(err);
-      expect(testGrader(255)).to.equal(err);
+      expect(testGrader(-12)).toBe(err);
+      expect(testGrader(-1)).toBe(err);
+      expect(testGrader(101)).toBe(err);
+      expect(testGrader(255)).toBe(err);
     });
 
     it("other invalid inputs", () => {
-      expect(testGrader("month")).to.equal(err);
-      expect(testGrader("February")).to.equal(err);
-      expect(testGrader("12")).to.equal(err);
-      expect(testGrader("1")).to.equal(err);
-      expect(testGrader([1, 2, 3])).to.equal(err);
-      expect(testGrader({})).to.equal(err);
+      expect(testGrader("month")).toBe(err);
+      expect(testGrader("February")).toBe(err);
+      expect(testGrader("12")).toBe(err);
+      expect(testGrader("1")).toBe(err);
+      expect(testGrader([1, 2, 3])).toBe(err);
+      expect(testGrader({})).toBe(err);
     });
   });
 });

--- a/topics/js/lessons/02-Conditionals/tests/07-daysInTheMonth.test.js
+++ b/topics/js/lessons/02-Conditionals/tests/07-daysInTheMonth.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { daysInTheMonth } from "../index.js";
 
 /**
@@ -7,45 +6,45 @@ import { daysInTheMonth } from "../index.js";
  * To test your answers to one of the problems above:
  * 1. Find the number of the problem you're working on
  * 2. Remove the `x` in `xdescribe` so that it reads `describe`
- * 3. Type `npm run test-02` in the Shell and hit Enter.
+ * 3. Type `npm run test:02` in the Shell and hit Enter.
  */
 
 describe("#7: daysInTheMonth", () => {
   describe("returns the correct number of days", () => {
     it("when the month is 1, 3, 5, 7, 8, 10, 12", () => {
-      expect(daysInTheMonth(1)).to.equal(31);
-      expect(daysInTheMonth(3)).to.equal(31);
-      expect(daysInTheMonth(5)).to.equal(31);
-      expect(daysInTheMonth(7)).to.equal(31);
-      expect(daysInTheMonth(8)).to.equal(31);
-      expect(daysInTheMonth(10)).to.equal(31);
-      expect(daysInTheMonth(12)).to.equal(31);
+      expect(daysInTheMonth(1)).toBe(31);
+      expect(daysInTheMonth(3)).toBe(31);
+      expect(daysInTheMonth(5)).toBe(31);
+      expect(daysInTheMonth(7)).toBe(31);
+      expect(daysInTheMonth(8)).toBe(31);
+      expect(daysInTheMonth(10)).toBe(31);
+      expect(daysInTheMonth(12)).toBe(31);
     });
 
     it("when the month is 4, 6, 9, 11", () => {
-      expect(daysInTheMonth(4)).to.equal(30);
-      expect(daysInTheMonth(6)).to.equal(30);
-      expect(daysInTheMonth(9)).to.equal(30);
-      expect(daysInTheMonth(11)).to.equal(30);
+      expect(daysInTheMonth(4)).toBe(30);
+      expect(daysInTheMonth(6)).toBe(30);
+      expect(daysInTheMonth(9)).toBe(30);
+      expect(daysInTheMonth(11)).toBe(30);
     });
 
     it("when the month is 2", () => {
-      expect(daysInTheMonth(2)).to.equal(28);
+      expect(daysInTheMonth(2)).toBe(28);
     });
   });
 
   it("handles invalid inputs correctly", () => {
     const err = "Not a valid month.";
 
-    expect(daysInTheMonth(-12)).to.equal(err);
-    expect(daysInTheMonth(-1)).to.equal(err);
-    expect(daysInTheMonth(0)).to.equal(err);
-    expect(daysInTheMonth(15)).to.equal(err);
-    expect(daysInTheMonth("month")).to.equal(err);
-    expect(daysInTheMonth("February")).to.equal(err);
-    expect(daysInTheMonth("12")).to.equal(err);
-    expect(daysInTheMonth("1")).to.equal(err);
-    expect(daysInTheMonth([1, 2, 3])).to.equal(err);
-    expect(daysInTheMonth({})).to.equal(err);
+    expect(daysInTheMonth(-12)).toBe(err);
+    expect(daysInTheMonth(-1)).toBe(err);
+    expect(daysInTheMonth(0)).toBe(err);
+    expect(daysInTheMonth(15)).toBe(err);
+    expect(daysInTheMonth("month")).toBe(err);
+    expect(daysInTheMonth("February")).toBe(err);
+    expect(daysInTheMonth("12")).toBe(err);
+    expect(daysInTheMonth("1")).toBe(err);
+    expect(daysInTheMonth([1, 2, 3])).toBe(err);
+    expect(daysInTheMonth({})).toBe(err);
   });
 });

--- a/topics/js/lessons/03-Methods-and-Functions/tests/01-helloWorld.test.js
+++ b/topics/js/lessons/03-Methods-and-Functions/tests/01-helloWorld.test.js
@@ -1,12 +1,11 @@
 import { helloWorld } from "../01-helloWorld.js";
-import { expect } from "chai";
 
 describe("#1: helloWorld", () => {
   it("returns a string", () => {
-    expect(helloWorld()).to.be.a("string");
+    expect(typeof helloWorld()).toBe("string");
   });
 
   it("returns the phrase 'Hello World!'", () => {
-    expect(helloWorld()).to.equal("Hello World!");
+    expect(helloWorld()).toBe("Hello World!");
   });
 });

--- a/topics/js/lessons/03-Methods-and-Functions/tests/02-helloWorldRedux.test.js
+++ b/topics/js/lessons/03-Methods-and-Functions/tests/02-helloWorldRedux.test.js
@@ -1,14 +1,13 @@
 import { helloWorldRedux } from "../02-helloWorldRedux.js";
-import { expect } from "chai";
 
 describe("#2: helloWorldRedux", () => {
   it("returns a personalized greeting if a name is passed in", () => {
-    expect(helloWorldRedux("Markus")).to.equal("Hello Markus!");
-    expect(helloWorldRedux("Jon")).to.equal("Hello Jon!");
-    expect(helloWorldRedux("Sally")).to.equal("Hello Sally!");
+    expect(helloWorldRedux("Markus")).toBe("Hello Markus!");
+    expect(helloWorldRedux("Jon")).toBe("Hello Jon!");
+    expect(helloWorldRedux("Sally")).toBe("Hello Sally!");
   });
 
   it('returns the phrase "Hello World!" if name is undefined', () => {
-    expect(helloWorldRedux()).to.equal("Hello World!");
+    expect(helloWorldRedux()).toBe("Hello World!");
   });
 });

--- a/topics/js/lessons/03-Methods-and-Functions/tests/03-uppercaseThis.test.js
+++ b/topics/js/lessons/03-Methods-and-Functions/tests/03-uppercaseThis.test.js
@@ -1,27 +1,26 @@
 import { uppercaseThis } from "../03-uppercaseThis.js";
-import { expect } from "chai";
 
 describe("#3: uppercaseThis", () => {
   it("returns a string", () => {
-    expect(uppercaseThis("zzzz")).to.be.a("string");
-    expect(uppercaseThis("aaaa")).to.be.a("string");
-    expect(uppercaseThis("BBBB")).to.be.a("string");
-    expect(uppercaseThis("cCcC")).to.be.a("string");
-    expect(uppercaseThis("d1D2d3")).to.be.a("string");
+    expect(typeof uppercaseThis("zzzz")).toBe("string");
+    expect(typeof uppercaseThis("aaaa")).toBe("string");
+    expect(typeof uppercaseThis("BBBB")).toBe("string");
+    expect(typeof uppercaseThis("cCcC")).toBe("string");
+    expect(typeof uppercaseThis("d1D2d3")).toBe("string");
   });
 
   describe("returns the phrase completely capitalized", () => {
     it("when the phrase is all lowercase", () => {
-      expect(uppercaseThis("aaaa")).to.equal("AAAA");
+      expect(uppercaseThis("aaaa")).toBe("AAAA");
     });
 
     it("when the phrase is already all capitalized", () => {
-      expect(uppercaseThis("BBBB")).to.equal("BBBB");
+      expect(uppercaseThis("BBBB")).toBe("BBBB");
     });
 
     it("when the phrase has mixed capitals", () => {
-      expect(uppercaseThis("cCcC")).to.equal("CCCC");
-      expect(uppercaseThis("d1D2d3")).to.equal("D1D2D3");
+      expect(uppercaseThis("cCcC")).toBe("CCCC");
+      expect(uppercaseThis("d1D2d3")).toBe("D1D2D3");
     });
   });
 });

--- a/topics/js/lessons/03-Methods-and-Functions/tests/04-doesItAddUp.test.js
+++ b/topics/js/lessons/03-Methods-and-Functions/tests/04-doesItAddUp.test.js
@@ -1,18 +1,17 @@
 import { doesItAddUp } from "../04-doesItAddUp.js";
-import { expect } from "chai";
 
 describe("#4: doesItAddUp", () => {
   it("returns true -> first two inputs equal the third", () => {
-    expect(doesItAddUp(1, 2, 3)).to.be.true;
-    expect(doesItAddUp(2, 1, 3)).to.be.true;
-    expect(doesItAddUp(4, 4, 8)).to.be.true;
-    expect(doesItAddUp(10, 20, 30)).to.be.true;
+    expect(doesItAddUp(1, 2, 3)).toBe(true);
+    expect(doesItAddUp(2, 1, 3)).toBe(true);
+    expect(doesItAddUp(4, 4, 8)).toBe(true);
+    expect(doesItAddUp(10, 20, 30)).toBe(true);
   });
 
   it("returns false -> first two inputs don't equal the third", () => {
-    expect(doesItAddUp(1, 5, 3)).to.be.false;
-    expect(doesItAddUp(22, 64, 33)).to.be.false;
-    expect(doesItAddUp(1, 1, 1)).to.be.false;
-    expect(doesItAddUp(1, 9, 2)).to.be.false;
+    expect(doesItAddUp(1, 5, 3)).toBe(false);
+    expect(doesItAddUp(22, 64, 33)).toBe(false);
+    expect(doesItAddUp(1, 1, 1)).toBe(false);
+    expect(doesItAddUp(1, 9, 2)).toBe(false);
   });
 });

--- a/topics/js/lessons/03-Methods-and-Functions/tests/05-arrayToString.test.js
+++ b/topics/js/lessons/03-Methods-and-Functions/tests/05-arrayToString.test.js
@@ -1,19 +1,18 @@
 import { arrayToString } from "../05-arrayToString.js";
-import { expect } from "chai";
 
 describe("#5: arrayToString", () => {
   const array = ["cat", "dog", "moo"];
   describe("returns the correct string", () => {
     it("when the separator is an empty string ('')", () => {
-      expect(arrayToString(array, "")).to.equal("catdogmoo");
+      expect(arrayToString(array, "")).toBe("catdogmoo");
     });
 
     it("when the separator is a single space (' ')", () => {
-      expect(arrayToString(array, " ")).to.equal("cat dog moo");
+      expect(arrayToString(array, " ")).toBe("cat dog moo");
     });
 
     it("when the separator is any other character sequence", () => {
-      expect(arrayToString(array, "+-%")).to.equal("cat+-%dog+-%moo");
+      expect(arrayToString(array, "+-%")).toBe("cat+-%dog+-%moo");
     });
   });
 });

--- a/topics/js/lessons/03-Methods-and-Functions/tests/06-smallTogetherNow.test.js
+++ b/topics/js/lessons/03-Methods-and-Functions/tests/06-smallTogetherNow.test.js
@@ -1,18 +1,17 @@
 import { smallTogetherNow } from "../06-smallTogetherNow.js";
-import { expect } from "chai";
 
 describe("#6: smallTogetherNow", () => {
   describe("returns a unified, lowercase string", () => {
     it("when two uppercase input strings are passed in", () => {
-      expect(smallTogetherNow("HELLO", "WORLD")).to.equal("helloworld");
+      expect(smallTogetherNow("HELLO", "WORLD")).toBe("helloworld");
     });
 
     it("when two lowercase input strings are passed in", () => {
-      expect(smallTogetherNow("hello", "world")).to.equal("helloworld");
+      expect(smallTogetherNow("hello", "world")).toBe("helloworld");
     });
 
     it("when input strings of mixed cases are passed in", () => {
-      expect(smallTogetherNow("HeLLo", "WorLD")).to.equal("helloworld");
+      expect(smallTogetherNow("HeLLo", "WorLD")).toBe("helloworld");
     });
   });
 });

--- a/topics/js/lessons/03-Methods-and-Functions/tests/07-dogAndOwnerInfo.test.js
+++ b/topics/js/lessons/03-Methods-and-Functions/tests/07-dogAndOwnerInfo.test.js
@@ -1,22 +1,21 @@
 import { dogAndOwnerInfo } from "../07-dogAndOwnerInfo.js";
-import { expect } from "chai";
 
 describe("#7: Dog owners and their dogs", () => {
   describe("returns the correct phrase", () => {
     it("when dog is older than their owner", () => {
-      expect(dogAndOwnerInfo("Turbo", 10, "Richard", 55)).to.equal(
+      expect(dogAndOwnerInfo("Turbo", 10, "Richard", 55)).toBe(
         "Turbo is older than their owner, Richard, by 15 years."
       );
     });
 
     it("when owner is older than their dog", () => {
-      expect(dogAndOwnerInfo("Fido", 1, "Sara", 15)).to.equal(
+      expect(dogAndOwnerInfo("Fido", 1, "Sara", 15)).toBe(
         "Sara is older than their dog, Fido, by 8 years."
       );
     });
 
     it("owner and dog are the same age", () => {
-      expect(dogAndOwnerInfo("Star", 2, "John", 14)).to.equal(
+      expect(dogAndOwnerInfo("Star", 2, "John", 14)).toBe(
         "John and Star are both 14 years old."
       );
     });

--- a/topics/js/lessons/03-Methods-and-Functions/tests/08-doesTheMathWork.test.js
+++ b/topics/js/lessons/03-Methods-and-Functions/tests/08-doesTheMathWork.test.js
@@ -1,68 +1,67 @@
 import { doesTheMathWork } from "../08-doesTheMathWork.js";
-import { expect } from "chai";
 
 describe("#8: doesTheMathWork", () => {
   describe("returns a string", () => {
     it("for addition", () => {
-      expect(doesTheMathWork(1, 2, 3)).to.be.a("string");
-      expect(doesTheMathWork(5, 2, 7)).to.be.a("string");
-      expect(doesTheMathWork(10, 2, 12)).to.be.a("string");
+      expect(typeof doesTheMathWork(1, 2, 3)).toBe("string");
+      expect(typeof doesTheMathWork(5, 2, 7)).toBe("string");
+      expect(typeof doesTheMathWork(10, 2, 12)).toBe("string");
     });
 
     it("for subtraction", () => {
-      expect(doesTheMathWork(3, 2, 1)).to.be.a("string");
-      expect(doesTheMathWork(7, 2, 5)).to.be.a("string");
-      expect(doesTheMathWork(12, 2, 10)).to.be.a("string");
+      expect(typeof doesTheMathWork(3, 2, 1)).toBe("string");
+      expect(typeof doesTheMathWork(7, 2, 5)).toBe("string");
+      expect(typeof doesTheMathWork(12, 2, 10)).toBe("string");
     });
 
     it("for multiplication", () => {
-      expect(doesTheMathWork(3, 3, 9)).to.be.a("string");
-      expect(doesTheMathWork(15, 5, 75)).to.be.a("string");
-      expect(doesTheMathWork(12, 2, 24)).to.be.a("string");
+      expect(typeof doesTheMathWork(3, 3, 9)).toBe("string");
+      expect(typeof doesTheMathWork(15, 5, 75)).toBe("string");
+      expect(typeof doesTheMathWork(12, 2, 24)).toBe("string");
     });
 
     it("for division", () => {
-      expect(doesTheMathWork(50, 2, 25)).to.be.a("string");
-      expect(doesTheMathWork(81, 9, 9)).to.be.a("string");
-      expect(doesTheMathWork(48, 8, 6)).to.be.a("string");
+      expect(typeof doesTheMathWork(50, 2, 25)).toBe("string");
+      expect(typeof doesTheMathWork(81, 9, 9)).toBe("string");
+      expect(typeof doesTheMathWork(48, 8, 6)).toBe("string");
     });
 
     it("for no operation", () => {
-      expect(doesTheMathWork(1, 99, 72)).to.be.a("string");
-      expect(doesTheMathWork(5, 84, 7)).to.be.a("string");
-      expect(doesTheMathWork(11, 222, 333)).to.be.a("string");
+      expect(typeof doesTheMathWork(1, 99, 72)).toBe("string");
+      expect(typeof doesTheMathWork(5, 84, 7)).toBe("string");
+      expect(typeof doesTheMathWork(11, 222, 333)).toBe("string");
     });
   });
 
   describe("returns the correct operation", () => {
     it("first two inputs add (+) to third input -> 'addition'", () => {
-      expect(doesTheMathWork(1, 2, 3)).to.equal("addition");
-      expect(doesTheMathWork(5, 2, 7)).to.equal("addition");
-      expect(doesTheMathWork(10, 2, 12)).to.equal("addition");
+      expect(doesTheMathWork(1, 2, 3)).toBe("addition");
+      expect(doesTheMathWork(5, 2, 7)).toBe("addition");
+      expect(doesTheMathWork(10, 2, 12)).toBe("addition");
     });
 
     it("first two inputs subtract (-) to third input -> 'subtraction'", () => {
-      expect(doesTheMathWork(3, 2, 1)).to.equal("subtraction");
-      expect(doesTheMathWork(7, 2, 5)).to.equal("subtraction");
-      expect(doesTheMathWork(12, 2, 10)).to.equal("subtraction");
+      expect(doesTheMathWork(3, 2, 1)).toBe("subtraction");
+      expect(doesTheMathWork(7, 2, 5)).toBe("subtraction");
+      expect(doesTheMathWork(12, 2, 10)).toBe("subtraction");
     });
 
     it("first two inputs multiply (*) to third input -> 'multiplication'", () => {
-      expect(doesTheMathWork(3, 3, 9)).to.equal("multiplication");
-      expect(doesTheMathWork(15, 5, 75)).to.equal("multiplication");
-      expect(doesTheMathWork(12, 2, 24)).to.equal("multiplication");
+      expect(doesTheMathWork(3, 3, 9)).toBe("multiplication");
+      expect(doesTheMathWork(15, 5, 75)).toBe("multiplication");
+      expect(doesTheMathWork(12, 2, 24)).toBe("multiplication");
     });
 
     it("first two inputs divide (/) to third input -> 'division'", () => {
-      expect(doesTheMathWork(50, 2, 25)).to.equal("division");
-      expect(doesTheMathWork(81, 9, 9)).to.equal("division");
-      expect(doesTheMathWork(48, 8, 6)).to.equal("division");
+      expect(doesTheMathWork(50, 2, 25)).toBe("division");
+      expect(doesTheMathWork(81, 9, 9)).toBe("division");
+      expect(doesTheMathWork(48, 8, 6)).toBe("division");
     });
 
     it("first two inputs don't resolve to third input -> 'no operation'", () => {
-      expect(doesTheMathWork(1, 99, 72)).to.equal("no operation");
-      expect(doesTheMathWork(5, 84, 7)).to.equal("no operation");
-      expect(doesTheMathWork(11, 222, 333)).to.equal("no operation");
+      expect(doesTheMathWork(1, 99, 72)).toBe("no operation");
+      expect(doesTheMathWork(5, 84, 7)).toBe("no operation");
+      expect(doesTheMathWork(11, 222, 333)).toBe("no operation");
     });
   });
 });

--- a/topics/js/lessons/03-Methods-and-Functions/tests/09-allWordsLength.test.js
+++ b/topics/js/lessons/03-Methods-and-Functions/tests/09-allWordsLength.test.js
@@ -1,5 +1,4 @@
 import { allWordsLength } from "../09-allWordsLength.js";
-import { expect } from "chai";
 
 describe("#9: allWordsLength", () => {
   const testWords = [
@@ -13,7 +12,7 @@ describe("#9: allWordsLength", () => {
     testWords.forEach((array) => {
       const func = (a) => a.join("").length;
       const result = func(array);
-      expect(allWordsLength(array)).to.be.a("number");
+      expect(typeof allWordsLength(array)).toBe("number");
     });
   });
 
@@ -22,7 +21,7 @@ describe("#9: allWordsLength", () => {
       const func = (a) => a.join("").length;
       const result = func(array);
       it(`${JSON.stringify(array)} -> ${result}`, () => {
-        expect(allWordsLength(array)).to.equal(result);
+        expect(allWordsLength(array)).toBe(result);
       });
     });
   });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/01-measurer.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/01-measurer.test.js
@@ -1,11 +1,7 @@
-import { expect } from "chai";
 import { measurer } from "../01-measurer.js";
 
 describe("#1: measurer", () => {
-  expect(measurer).to.be.a(
-    "function",
-    "No `measurer` function found; please check if defined and exported correctly."
-  );
+  expect(typeof measurer).toBe("function");
 
   const resultA = measurer([]);
   const resultB = measurer([1]);
@@ -13,21 +9,21 @@ describe("#1: measurer", () => {
   const resultD = measurer(["abc", true, { a: 1, b: 2 }]);
 
   it("returns a number", () => {
-    expect(resultA).to.be.a("number");
-    expect(resultB).to.be.a("number");
-    expect(resultC).to.be.a("number");
-    expect(resultD).to.be.a("number");
+    expect(typeof resultA).toBe("number");
+    expect(typeof resultB).toBe("number");
+    expect(typeof resultC).toBe("number");
+    expect(typeof resultD).toBe("number");
   });
 
   describe("returns the correct number of items", () => {
     it("when the array is empty", () => {
-      expect(resultA).to.equal(0);
+      expect(resultA).toBe(0);
     });
 
     it("when the array is not empty", () => {
-      expect(resultB).to.equal(1);
-      expect(resultC).to.equal(5);
-      expect(resultD).to.equal(3);
+      expect(resultB).toBe(1);
+      expect(resultC).toBe(5);
+      expect(resultD).toBe(3);
     });
   });
 });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/02-indexer.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/02-indexer.test.js
@@ -1,44 +1,40 @@
 import { indexer } from "../02-indexer.js";
-import { expect } from "chai";
 import { arr1, arr2, arr3, arr4 } from "../data/02-indexer.data.js";
 
 describe("#2: indexer", () => {
-  expect(indexer).to.be.a(
-    "function",
-    "No `indexer` function found; please check if defined and exported correctly."
-  );
+  expect(typeof indexer).toBe("function");
 
   describe("when idx is not a valid array index value", () => {
     it("returns 'Invalid index.'", () => {
       const message = "Invalid index.";
 
-      expect(indexer(arr1, -19)).to.equal(message);
-      expect(indexer(arr1, 2)).to.equal(message);
+      expect(indexer(arr1, -19)).toBe(message);
+      expect(indexer(arr1, 2)).toBe(message);
 
-      expect(indexer(arr2, -99)).to.equal(message);
-      expect(indexer(arr2, 10)).to.equal(message);
+      expect(indexer(arr2, -99)).toBe(message);
+      expect(indexer(arr2, 10)).toBe(message);
 
-      expect(indexer(arr3, -2)).to.equal(message);
-      expect(indexer(arr3, 5)).to.equal(message);
+      expect(indexer(arr3, -2)).toBe(message);
+      expect(indexer(arr3, 5)).toBe(message);
 
-      expect(indexer(arr4, -8)).to.equal(message);
-      expect(indexer(arr4, 8)).to.equal(message);
+      expect(indexer(arr4, -8)).toBe(message);
+      expect(indexer(arr4, 8)).toBe(message);
     });
   });
 
   describe("when idx is a valid array index value", () => {
     it("returns the value at the given index", () => {
-      expect(indexer(arr1, 0)).to.equal(1);
-      expect(indexer(arr2, 2)).to.equal("car");
-      expect(indexer(arr3, 4)).to.equal(101);
-      expect(indexer(arr4, 1)).to.equal(1332211);
+      expect(indexer(arr1, 0)).toBe(1);
+      expect(indexer(arr2, 2)).toBe("car");
+      expect(indexer(arr3, 4)).toBe(101);
+      expect(indexer(arr4, 1)).toBe(1332211);
     });
   });
 
   it("returns the array's first value when the index isn't defined", () => {
-    expect(indexer(arr1)).to.equal(1);
-    expect(indexer(arr2)).to.equal("business");
-    expect(indexer(arr3)).to.equal(1);
-    expect(indexer(arr4)).to.equal(true);
+    expect(indexer(arr1)).toBe(1);
+    expect(indexer(arr2)).toBe("business");
+    expect(indexer(arr3)).toBe(1);
+    expect(indexer(arr4)).toBe(true);
   });
 });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/03-frontOrBack.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/03-frontOrBack.test.js
@@ -1,47 +1,43 @@
 import { frontOrBack } from "../03-frontOrBack.js";
-import { expect } from "chai";
 
 describe("#3: frontOrBack", () => {
-  expect(frontOrBack).to.be.a(
-    "function",
-    "No `frontOrBack` function found; please check if defined and exported correctly."
-  );
+  expect(typeof frontOrBack).toBe("function");
 
   describe("returns a correctly modified array", () => {
     it('when place = "front"; action = "add"', () => {
       const arr1 = [1, 2, 3, 4];
       const empty = [];
 
-      expect(frontOrBack(arr1, "front", "add", 5)).to.deep.equal([
+      expect(frontOrBack(arr1, "front", "add", 5)).toEqual([
         5, 1, 2, 3, 4,
       ]);
-      expect(frontOrBack(empty, "front", "add", 5)).to.deep.equal([5]);
+      expect(frontOrBack(empty, "front", "add", 5)).toEqual([5]);
     });
 
     it('when place = "back"; action = "add"', () => {
       const arr1 = [1, 2, 3, 4];
       const empty = [];
 
-      expect(frontOrBack(arr1, "back", "add", 5)).to.deep.equal([
+      expect(frontOrBack(arr1, "back", "add", 5)).toEqual([
         1, 2, 3, 4, 5,
       ]);
-      expect(frontOrBack(empty, "back", "add", 5)).to.deep.equal([5]);
+      expect(frontOrBack(empty, "back", "add", 5)).toEqual([5]);
     });
 
     it('when place = "front"; action = "remove"', () => {
       const arr1 = [1, 2, 3, 4];
       const oneEle = ["one"];
 
-      expect(frontOrBack(arr1, "front", "remove", 5)).to.deep.equal([2, 3, 4]);
-      expect(frontOrBack(oneEle, "front", "remove", 5)).to.deep.equal([]);
+      expect(frontOrBack(arr1, "front", "remove", 5)).toEqual([2, 3, 4]);
+      expect(frontOrBack(oneEle, "front", "remove", 5)).toEqual([]);
     });
 
     it('when place = "back"; action = "remove"', () => {
       const arr1 = [1, 2, 3, 4];
       const oneEle = ["one"];
 
-      expect(frontOrBack(arr1, "back", "remove", 5)).to.deep.equal([1, 2, 3]);
-      expect(frontOrBack(oneEle, "back", "remove", 5)).to.deep.equal([]);
+      expect(frontOrBack(arr1, "back", "remove", 5)).toEqual([1, 2, 3]);
+      expect(frontOrBack(oneEle, "back", "remove", 5)).toEqual([]);
     });
   });
 });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/04-repeater.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/04-repeater.test.js
@@ -1,19 +1,15 @@
 import { repeater } from "../04-repeater.js";
-import { expect } from "chai";
 
 describe("#4: repeater", () => {
-  expect(repeater).to.be.a(
-    "function",
-    "No `repeater` function found; please check if defined and exported correctly."
-  );
+  expect(typeof repeater).toBe("function");
 
   describe("returns a string", () => {
     it("repeated 0 times -> an empty string", () => {
-      expect(repeater("empty string")).to.equal("");
+      expect(repeater("empty string")).toBe("");
     });
 
     it("repeated 1 time -> the input string", () => {
-      expect(repeater("one time only", 1)).to.equal("one time only");
+      expect(repeater("one time only", 1)).toBe("one time only");
     });
 
     describe("repeated multiple times", () => {
@@ -26,7 +22,7 @@ describe("#4: repeater", () => {
 
       strings.forEach(({ str, times, result }) => {
         it(`'${str}', ${times} -> '${result}'`, () => {
-          expect(repeater(str, times)).to.equal(result);
+          expect(repeater(str, times)).toBe(result);
         });
       });
     });
@@ -39,7 +35,7 @@ describe("#4: repeater", () => {
 
       negVals.forEach((val) => {
         const result = repeater(baseStr, val);
-        expect(result).to.equal("");
+        expect(result).toBe("");
       });
     });
   });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/05-disemvoweler.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/05-disemvoweler.test.js
@@ -1,5 +1,4 @@
 import { disemvoweler } from "../05-disemvoweler.js";
-import { expect } from "chai";
 import {
   noVowels,
   oneVowel,
@@ -8,16 +7,13 @@ import {
 } from "../data/05-disemvoweler.data.js";
 
 describe("#5: disemvoweler", () => {
-  expect(disemvoweler).to.be.a(
-    "function",
-    "No `disemvoweler` function found; please check if defined and exported correctly."
-  );
+  expect(typeof disemvoweler).toBe("function");
   describe("returns a string", () => {
     describe("no vowels -> same as the input string", () => {
       noVowels.forEach(({ str }) => {
         it(`'${str}' -> '${str}'`, () => {
           const testResult = disemvoweler(str);
-          expect(testResult).to.equal(str);
+          expect(testResult).toBe(str);
         });
       });
     });
@@ -27,7 +23,7 @@ describe("#5: disemvoweler", () => {
         oneVowel.forEach(({ str, result }) => {
           it(`'${str}' -> '${result}'`, () => {
             const testResult = disemvoweler(str);
-            expect(testResult).to.equal(result);
+            expect(testResult).toBe(result);
           });
         });
       });
@@ -36,7 +32,7 @@ describe("#5: disemvoweler", () => {
         multiVowels.forEach(({ str, result }) => {
           it(`'${str}' -> '${result}'`, () => {
             const testResult = disemvoweler(str);
-            expect(testResult).to.equal(result);
+            expect(testResult).toBe(result);
           });
         });
       });
@@ -47,7 +43,7 @@ describe("#5: disemvoweler", () => {
     hasUppercase.forEach(({ str, result }) => {
       it(`'${str}' -> '${result}'`, () => {
         const testResult = disemvoweler(str);
-        expect(testResult).to.equal(result);
+        expect(testResult).toBe(result);
       });
     });
   });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/06-valueLocator.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/06-valueLocator.test.js
@@ -1,32 +1,28 @@
 import { valueLocator } from "../06-valueLocator.js";
-import { expect } from "chai";
 import { arr, foundVals, notFoundVals } from "../data/06-valueLocator.data.js";
 
 describe("#6: valueLocator", () => {
-  expect(valueLocator).to.be.a(
-    "function",
-    "No `valueLocator` function found; please check if defined and exported correctly."
-  );
+  expect(typeof valueLocator).toBe("function");
 
   describe("when searchValue is found in the array", () => {
     it("returns phrase containing search term", () => {
       foundVals.forEach(({ val }) => {
         const foundResult = valueLocator(val, arr);
-        expect(foundResult).includes(val);
+        expect(foundResult).toContain(val);
       });
     });
 
     it("returns phrase containing original array", () => {
       foundVals.forEach(({ val }) => {
         const foundResult = valueLocator(val, arr);
-        expect(foundResult).includes(`[${arr}]`);
+        expect(foundResult).toContain(`[${arr}]`);
       });
     });
 
     it("returns phrase containing index of search term", () => {
       foundVals.forEach(({ val, idx }) => {
         const foundResult = valueLocator(val, arr);
-        expect(foundResult).includes(`at index ${idx}`);
+        expect(foundResult).toContain(`at index ${idx}`);
       });
     });
   });
@@ -35,21 +31,21 @@ describe("#6: valueLocator", () => {
     it("returns phrase containing searchTerm", () => {
       notFoundVals.forEach((val) => {
         const absentResult = valueLocator(val, arr);
-        expect(absentResult).includes(val);
+        expect(absentResult).toContain(val);
       });
     });
 
     it("returns phrase detailing the searchTerm is not found", () => {
       notFoundVals.forEach((val) => {
         const absentResult = valueLocator(val, arr);
-        expect(absentResult).includes("cannot be found in the array");
+        expect(absentResult).toContain("cannot be found in the array");
       });
     });
 
     it("returns phrase containing original array", () => {
       notFoundVals.forEach((val) => {
         const absentResult = valueLocator(val, arr);
-        expect(absentResult).includes(`[${arr}]`);
+        expect(absentResult).toContain(`[${arr}]`);
       });
     });
   });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/07-flipomatic.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/07-flipomatic.test.js
@@ -1,5 +1,4 @@
 import { flipomatic } from "../07-flipomatic.js";
-import { expect } from "chai";
 import {
   flipStart,
   flipEnd,
@@ -16,22 +15,19 @@ import {
 } from "../data/07-flipomatic.data.js";
 
 describe("#7: flipomatic", () => {
-  expect(flipomatic).to.be.a(
-    "function",
-    "No `flipomatic` function found; please check if defined and exported correctly."
-  );
+  expect(typeof flipomatic).toBe("function");
 
   describe("returns an array", () => {
     it("if there's a 'flip'", () => {
       flipArrs.forEach((arr) => {
         const result = flipomatic(arr);
-        expect(result).to.be.an("array");
+        expect(Array.isArray(result)).toBe(true);
       });
     });
     it("if there's no 'flip'", () => {
       noFlipArrs.forEach((arr) => {
         const result = flipomatic(arr);
-        expect(result).to.be.an("array");
+        expect(Array.isArray(result)).toBe(true);
       });
     });
   });
@@ -39,24 +35,24 @@ describe("#7: flipomatic", () => {
   describe("outputs an array of numbers, in the correct order", () => {
     describe("if there's a 'flip'", () => {
       it("at the front of the array", () => {
-        expect(flipomatic(flipStart)).to.deep.equal([5, 4, 3, 2, 1]);
+        expect(flipomatic(flipStart)).toEqual([5, 4, 3, 2, 1]);
       });
 
       it("at the back of the array", () => {
-        expect(flipomatic(flipEnd)).to.deep.equal([1, 2, 3, 4, 5]);
+        expect(flipomatic(flipEnd)).toEqual([1, 2, 3, 4, 5]);
       });
 
       it("somewhere in the middle of the array", () => {
-        expect(flipomatic(hasFlip1)).to.deep.equal([5, 4, 3, 2, 1]);
-        expect(flipomatic(hasFlip2)).to.deep.equal([5, 4, 3, 1, 2]);
-        expect(flipomatic(hasFlip3)).to.deep.equal([5, 4, 1, 2, 3]);
-        expect(flipomatic(hasFlip4)).to.deep.equal([5, 1, 2, 3, 4]);
+        expect(flipomatic(hasFlip1)).toEqual([5, 4, 3, 2, 1]);
+        expect(flipomatic(hasFlip2)).toEqual([5, 4, 3, 1, 2]);
+        expect(flipomatic(hasFlip3)).toEqual([5, 4, 1, 2, 3]);
+        expect(flipomatic(hasFlip4)).toEqual([5, 1, 2, 3, 4]);
       });
     });
 
     it("if there's no 'flip'", () => {
-      expect(flipomatic(noFlip1)).to.deep.equal(noFlip1);
-      expect(flipomatic(noFlip2)).to.deep.equal(noFlip2);
+      expect(flipomatic(noFlip1)).toEqual(noFlip1);
+      expect(flipomatic(noFlip2)).toEqual(noFlip2);
     });
   });
 
@@ -65,7 +61,7 @@ describe("#7: flipomatic", () => {
       twoFlip.forEach(({ val, ans }) => {
         it(`[${val}] => [${ans}]`, () => {
           const result = flipomatic(val);
-          expect(result).to.deep.equal(ans);
+          expect(result).toEqual(ans);
         });
       });
     });
@@ -74,7 +70,7 @@ describe("#7: flipomatic", () => {
       multiFlip.forEach(({ val, ans }) => {
         it(`[${val}] => [${ans}]`, () => {
           const result = flipomatic(val);
-          expect(result).to.deep.equal(ans);
+          expect(result).toEqual(ans);
         });
       });
     });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/08-uniqueCharsOnly.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/08-uniqueCharsOnly.test.js
@@ -1,5 +1,4 @@
 import { uniqueCharsOnly } from "../08-uniqueCharsOnly.js";
-import { expect } from "chai";
 import {
   singleRepeatingStr,
   fewCharRepeats,
@@ -8,17 +7,14 @@ import {
 } from "../data/08-uniqueCharsOnly.data.js";
 
 describe("#8: uniqueCharsOnly", () => {
-  expect(uniqueCharsOnly).to.be.a(
-    "function",
-    "No `uniqueCharsOnly` function found; please check if defined and exported correctly."
-  );
+  expect(typeof uniqueCharsOnly).toBe("function");
 
   describe("returns an array of the unique characters in the string", () => {
     describe("if the string is one repeating character", () => {
       singleRepeatingStr.forEach(({ val, ans }) => {
         it(`"${val}" => ${JSON.stringify(ans)}`, () => {
           const result = uniqueCharsOnly(val);
-          expect(result).to.deep.equal(ans);
+          expect(result).toEqual(ans);
         });
       });
     });
@@ -27,7 +23,7 @@ describe("#8: uniqueCharsOnly", () => {
       fewCharRepeats.forEach(({ val, ans }) => {
         it(`"${val}" => ${JSON.stringify(ans)}`, () => {
           const result = uniqueCharsOnly(val);
-          expect(result).to.deep.equal(ans);
+          expect(result).toEqual(ans);
         });
       });
     });
@@ -36,7 +32,7 @@ describe("#8: uniqueCharsOnly", () => {
       hasDoubleLetters.forEach(({ val, ans }) => {
         it(`"${val}" => ${JSON.stringify(ans)}`, () => {
           const result = uniqueCharsOnly(val);
-          expect(result).to.deep.equal(ans);
+          expect(result).toEqual(ans);
         });
       });
     });
@@ -45,7 +41,7 @@ describe("#8: uniqueCharsOnly", () => {
       allUniqueLetters.forEach(({ val, ans }) => {
         it(`"${val}" => ${JSON.stringify(ans)}`, () => {
           const result = uniqueCharsOnly(val);
-          expect(result).to.deep.equal(ans);
+          expect(result).toEqual(ans);
         });
       });
     });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/09-wordCalculator.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/09-wordCalculator.test.js
@@ -1,5 +1,4 @@
 import { wordCalculator } from "../09-wordCalculator.js";
-import { expect } from "chai";
 import {
   zeroStarts,
   oneCalcs,
@@ -10,26 +9,23 @@ import {
 } from "../data/09-wordCalculator.data.js";
 
 describe("#9: wordCalculator", () => {
-  expect(wordCalculator).to.be.a(
-    "function",
-    "No `wordCalculator` function found; please check if defined and exported correctly."
-  );
+  expect(typeof wordCalculator).toBe("function");
 
   it("returns a number", () => {
     allCalcs.forEach(({ nums, ops }) => {
-      expect(wordCalculator(nums, ops)).to.be.a("number");
+      expect(typeof wordCalculator(nums, ops)).toBe("number");
     });
   });
 
   it("has an initial value of 0", () => {
     zeroStarts.forEach(({ nums, ops }) => {
-      expect(wordCalculator(nums, ops)).to.equal(0);
+      expect(wordCalculator(nums, ops)).toBe(0);
     });
   });
 
   it("returns 0 if the operations are invalid", () => {
     invalidCalcs.forEach(({ nums, ops }) => {
-      expect(wordCalculator(nums, ops)).to.equal(0);
+      expect(wordCalculator(nums, ops)).toBe(0);
     });
   });
 
@@ -37,7 +33,7 @@ describe("#9: wordCalculator", () => {
     describe("when there's only one operation", () => {
       oneCalcs.forEach(({ nums, ops, result }) => {
         it(`[${nums}], [${ops}] -> ${result}`, () => {
-          expect(wordCalculator(nums, ops)).to.equal(result);
+          expect(wordCalculator(nums, ops)).toBe(result);
         });
       });
     });
@@ -45,7 +41,7 @@ describe("#9: wordCalculator", () => {
     describe("when there are two operations", () => {
       twoCalcs.forEach(({ nums, ops, result }) => {
         it(`[${nums}], [${ops}] -> ${result}`, () => {
-          expect(wordCalculator(nums, ops)).to.equal(result);
+          expect(wordCalculator(nums, ops)).toBe(result);
         });
       });
     });
@@ -53,7 +49,7 @@ describe("#9: wordCalculator", () => {
     describe("when there are three or more operations", () => {
       multiCalcs.forEach(({ nums, ops, result }) => {
         it(`[${nums}], [${ops}] -> ${result}`, () => {
-          expect(wordCalculator(nums, ops)).to.equal(result);
+          expect(wordCalculator(nums, ops)).toBe(result);
         });
       });
     });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/10-pairMultiplier.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/10-pairMultiplier.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { pairMultiplier } from "../10-pairMultiplier.js";
 import {
   firstArrSmaller,
@@ -7,16 +6,13 @@ import {
 } from "../data/10-pairMultiplier.data.js";
 
 describe("#10: pairMultiplier", () => {
-  expect(pairMultiplier).to.be.a(
-    "function",
-    "No `pairMultiplier` function found; please check if defined and exported correctly."
-  );
+  expect(typeof pairMultiplier).toBe("function");
 
   describe("returns an array of multiplied numbers, in the correct order", () => {
     describe("when both arrays are the same size", () => {
       sameArraySizes.forEach(({ arr1, arr2, result }) => {
         it(`[${arr1}], [${arr2}] -> [${result}]`, () => {
-          expect(pairMultiplier(arr1, arr2)).to.deep.equal(result);
+          expect(pairMultiplier(arr1, arr2)).toEqual(result);
         });
       });
     });
@@ -24,7 +20,7 @@ describe("#10: pairMultiplier", () => {
     describe("first array smaller than second", () => {
       firstArrSmaller.forEach(({ arr1, arr2, result }) => {
         it(`[${arr1}], [${arr2}] -> [${result}]`, () => {
-          expect(pairMultiplier(arr1, arr2)).to.deep.equal(result);
+          expect(pairMultiplier(arr1, arr2)).toEqual(result);
         });
       });
     });
@@ -32,7 +28,7 @@ describe("#10: pairMultiplier", () => {
     describe("second array smaller than first", () => {
       secondArrSmaller.forEach(({ arr1, arr2, result }) => {
         it(`[${arr1}], [${arr2}] -> [${result}]`, () => {
-          expect(pairMultiplier(arr1, arr2)).to.deep.equal(result);
+          expect(pairMultiplier(arr1, arr2)).toEqual(result);
         });
       });
     });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/11-fizzbuzz.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/11-fizzbuzz.test.js
@@ -1,22 +1,18 @@
-import { expect } from "chai";
 import { fizzBuzz } from "../11-fizzbuzz.js";
 import { lengthTest } from "../data/11-fizzBuzz.data.js";
 
 describe("#11: fizzBuzz", () => {
-  expect(fizzBuzz).to.be.a(
-    "function",
-    "No `fizzBuzz` function found; please check if defined and exported correctly."
-  );
+  expect(typeof fizzBuzz).toBe("function");
 
   const result = fizzBuzz(100);
 
   it("returns an array", () => {
-    expect(result).to.be.an("array");
+    expect(Array.isArray(result)).toBe(true);
   });
 
   it("the array is the correct length", () => {
     lengthTest.map((length) => {
-      expect(fizzBuzz(length)).to.have.lengthOf(length);
+      expect(fizzBuzz(length)).toHaveLength(length);
     });
   });
 
@@ -24,27 +20,27 @@ describe("#11: fizzBuzz", () => {
     const eachStringNumAppears = result
       .filter((_, idx) => (idx + 1) % 3 !== 0 && (idx + 1) % 4 !== 0)
       .every((entry) => typeof entry === "number");
-    expect(eachStringNumAppears).to.be.true;
+    expect(eachStringNumAppears).toBe(true);
   });
 
   it("each number divisible only by 3 is `Fizz`", () => {
     const eachFizzAppears = result
       .filter((_, idx) => (idx + 1) % 3 === 0 && (idx + 1) % 12 !== 0)
       .every((entry) => entry === "Fizz");
-    expect(eachFizzAppears).to.be.true;
+    expect(eachFizzAppears).toBe(true);
   });
 
   it("each number divisible only by 4 is `Buzz`", () => {
     const eachBuzzAppears = result
       .filter((_, idx) => (idx + 1) % 4 === 0 && (idx + 1) % 12 !== 0)
       .every((entry) => entry === "Buzz");
-    expect(eachBuzzAppears).to.be.true;
+    expect(eachBuzzAppears).toBe(true);
   });
 
   it("each number divisible by both 3 and 4 is `FizzBuzz`", () => {
     const eachFizzBuzzAppears = result
       .filter((_, idx) => (idx + 1) % 12 === 0)
       .every((entry) => entry === "FizzBuzz");
-    expect(eachFizzBuzzAppears).to.be.true;
+    expect(eachFizzBuzzAppears).toBe(true);
   });
 });

--- a/topics/js/lessons/04-Arrays-and-Loops/tests/12-maxDifference.test.js
+++ b/topics/js/lessons/04-Arrays-and-Loops/tests/12-maxDifference.test.js
@@ -1,5 +1,3 @@
-import { expect } from "chai";
-import { describe } from "mocha";
 import { maxDifference } from "../12-maxDifference.js";
 import {
   oneNum,
@@ -15,40 +13,40 @@ describe("#12: maxDifference", () => {
 
     allArrs.forEach((arr) => {
       const result = maxDifference(arr);
-      expect(result).to.be.a("number");
+      expect(typeof result).toBe("number");
     });
   });
 
   describe("returns the max difference of values", () => {
     it("for a 1 number array", () => {
       const result = maxDifference(oneNum);
-      expect(result).to.equal(0);
+      expect(result).toBe(0);
     });
 
     describe("for a multi number array", () => {
       it("of all the same number", () => {
         allSameNums.forEach((arr) => {
           const result = maxDifference(arr);
-          expect(result).to.equal(0);
+          expect(result).toBe(0);
         });
       });
 
       it("of all different numbers", () => {
         twoNums.forEach((arr) => {
           const result = maxDifference(arr);
-          expect(result).to.equal(1);
+          expect(result).toBe(1);
         });
 
         threeNums.forEach((arr) => {
           const result = maxDifference(arr);
-          expect(result).to.equal(2);
+          expect(result).toBe(2);
         });
       });
 
       it("with some repeats", () => {
         withRepeats.forEach((arr) => {
           const result = maxDifference(arr);
-          expect(result).to.equal(4);
+          expect(result).toBe(4);
         });
       });
     });

--- a/topics/js/lessons/06-Objects/tests/01-isAnObject.test.js
+++ b/topics/js/lessons/06-Objects/tests/01-isAnObject.test.js
@@ -1,32 +1,31 @@
 import { isAnObject } from "../01-isAnObject.js";
-import { expect } from "chai";
 
 describe("#1: isAnObject", () => {
   describe("returns false", () => {
     it("for a string", () => {
-      expect(isAnObject("string")).to.be.false;
+      expect(isAnObject("string")).toBe(false);
     });
 
     it("for a number", () => {
-      expect(isAnObject(42)).to.be.false;
+      expect(isAnObject(42)).toBe(false);
     });
 
     it("for a boolean", () => {
-      expect(isAnObject(true)).to.be.false;
+      expect(isAnObject(true)).toBe(false);
     });
 
     it("for an array", () => {
-      expect(isAnObject([1, 2, 3])).to.be.false;
+      expect(isAnObject([1, 2, 3])).toBe(false);
     });
 
     it("for null", () => {
-      expect(isAnObject(null)).to.be.false;
+      expect(isAnObject(null)).toBe(false);
     });
   });
 
   describe("returns true", () => {
     it("for an object", () => {
-      expect(isAnObject({ fruit: "banana" })).to.be.true;
+      expect(isAnObject({ fruit: "banana" })).toBe(true);
     });
   });
 });

--- a/topics/js/lessons/06-Objects/tests/02-valueReader.test.js
+++ b/topics/js/lessons/06-Objects/tests/02-valueReader.test.js
@@ -1,20 +1,19 @@
-import { expect } from "chai";
 import { dataObj } from "../data/02-valueReader.data.js";
 import { valueReader } from "../02-valueReader.js";
 
 describe("#2: valueReader", () => {
   describe("returns the correct value", () => {
     it("when the key-value pair exists in the data object", () => {
-      expect(valueReader("alfa", dataObj)).to.equal("hello world");
-      expect(valueReader("bravo", dataObj)).to.equal(123);
-      expect(valueReader("foxtrot", dataObj)).to.equal(false);
-      expect(valueReader("lima", dataObj)).to.deep.equal([1, 2, 3]);
-      expect(valueReader("tango", dataObj)).to.deep.equal({ a: 1 });
+      expect(valueReader("alfa", dataObj)).toBe("hello world");
+      expect(valueReader("bravo", dataObj)).toBe(123);
+      expect(valueReader("foxtrot", dataObj)).toBe(false);
+      expect(valueReader("lima", dataObj)).toEqual([1, 2, 3]);
+      expect(valueReader("tango", dataObj)).toEqual({ a: 1 });
     });
 
     it("when the key does not exist in the data object", () => {
-      expect(valueReader("nope", dataObj)).to.equal(undefined);
-      expect(valueReader("sierra", dataObj)).to.equal(undefined);
+      expect(valueReader("nope", dataObj)).toBe(undefined);
+      expect(valueReader("sierra", dataObj)).toBe(undefined);
     });
   });
 });

--- a/topics/js/lessons/06-Objects/tests/03-objectCount.test.js
+++ b/topics/js/lessons/06-Objects/tests/03-objectCount.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { objectCount } from "../03-objectCount.js";
 import {
   emptyObject,
@@ -13,54 +12,54 @@ import {
 
 describe("#3: objectCount", () => {
   it("returns a number", () => {
-    expect(objectCount(emptyObject)).to.be.a("number");
-    expect(objectCount(noObjects)).to.be.a("number");
-    expect(objectCount(oneObject)).to.be.a("number");
-    expect(objectCount(multipleTopLevelObjects)).to.be.a("number");
+    expect(typeof objectCount(emptyObject)).toBe("number");
+    expect(typeof objectCount(noObjects)).toBe("number");
+    expect(typeof objectCount(oneObject)).toBe("number");
+    expect(typeof objectCount(multipleTopLevelObjects)).toBe("number");
   });
 
   describe("returns the correct number of objects found within the input object", () => {
     it("when the object is empty", () => {
-      expect(objectCount(emptyObject)).to.be.a("number");
-      expect(objectCount(emptyObject)).to.equal(0);
+      expect(typeof objectCount(emptyObject)).toBe("number");
+      expect(objectCount(emptyObject)).toBe(0);
     });
 
     it("when the object has no object values", () => {
-      expect(objectCount(noObjects)).to.be.a("number");
-      expect(objectCount(noObjects)).to.equal(0);
+      expect(typeof objectCount(noObjects)).toBe("number");
+      expect(objectCount(noObjects)).toBe(0);
     });
 
     it("when the object has 1 object value", () => {
-      expect(objectCount(oneObject)).to.be.a("number");
-      expect(objectCount(oneObject)).to.equal(1);
+      expect(typeof objectCount(oneObject)).toBe("number");
+      expect(objectCount(oneObject)).toBe(1);
     });
 
     it("when the object has multiple object values", () => {
-      expect(objectCount(multipleTopLevelObjects)).to.be.a("number");
-      expect(objectCount(multipleTopLevelObjects)).to.equal(4);
+      expect(typeof objectCount(multipleTopLevelObjects)).toBe("number");
+      expect(objectCount(multipleTopLevelObjects)).toBe(4);
     });
   });
 
   describe("BONUS", () => {
     describe("also examines array sub-values for objects and adds any found to the total count", () => {
       it("when the value array is empty", () => {
-        expect(objectCount(noObjectsEmptyBonus)).to.be.a("number");
-        expect(objectCount(noObjectsEmptyBonus)).to.equal(0);
+        expect(typeof objectCount(noObjectsEmptyBonus)).toBe("number");
+        expect(objectCount(noObjectsEmptyBonus)).toBe(0);
       });
 
       it("when the value array has no objects", () => {
-        expect(objectCount(noObjectsWithElementsBonus)).to.be.a("number");
-        expect(objectCount(noObjectsWithElementsBonus)).to.equal(0);
+        expect(typeof objectCount(noObjectsWithElementsBonus)).toBe("number");
+        expect(objectCount(noObjectsWithElementsBonus)).toBe(0);
       });
 
       it("when the value array has 1 object", () => {
-        expect(objectCount(oneObjectBonus)).to.be.a("number");
-        expect(objectCount(oneObjectBonus)).to.equal(2);
+        expect(typeof objectCount(oneObjectBonus)).toBe("number");
+        expect(objectCount(oneObjectBonus)).toBe(2);
       });
 
       it("when the value array has multiple objects", () => {
-        expect(objectCount(multipleKeysWithObjectsBonus)).to.be.a("number");
-        expect(objectCount(multipleKeysWithObjectsBonus)).to.equal(9);
+        expect(typeof objectCount(multipleKeysWithObjectsBonus)).toBe("number");
+        expect(objectCount(multipleKeysWithObjectsBonus)).toBe(9);
       });
     });
   });

--- a/topics/js/lessons/06-Objects/tests/04-priceTransformer.test.js
+++ b/topics/js/lessons/06-Objects/tests/04-priceTransformer.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { priceTransformer } from "../04-priceTransformer.js";
 import { shortPrices } from "../data/04-priceTransformer.data.js";
 
@@ -6,16 +5,16 @@ describe("#4: priceTransformer", () => {
   const transformedObj = priceTransformer(shortPrices);
 
   it("returns an object", () => {
-    expect(transformedObj).to.be.an("object");
+    expect(typeof transformedObj).toBe("object");
   });
 
   describe("the returned object", () => {
     it("does not have the 'food' key", () => {
-      expect(transformedObj).to.not.have.property("food");
+      expect(transformedObj).not.toHaveProperty("food");
     });
 
     it("does not have the 'price' key", () => {
-      expect(transformedObj).to.not.have.property("price");
+      expect(transformedObj).not.toHaveProperty("price");
     });
 
     it("has each of the food values as keys", () => {
@@ -23,7 +22,7 @@ describe("#4: priceTransformer", () => {
       const hasAllFoodKeys = Object.keys(transformedObj).every(
         (key) => foodKeys.indexOf(key) !== -1
       );
-      expect(hasAllFoodKeys).to.be.true;
+      expect(hasAllFoodKeys).toBe(true);
     });
 
     it("has each of the price values as values", () => {
@@ -31,7 +30,7 @@ describe("#4: priceTransformer", () => {
       const hasAllPriceValues = Object.values(transformedObj).every(
         (values) => priceValues.indexOf(values) !== -1
       );
-      expect(hasAllPriceValues).to.be.true;
+      expect(hasAllPriceValues).toBe(true);
     });
   });
 });

--- a/topics/js/lessons/06-Objects/tests/05-nullDeleter.test.js
+++ b/topics/js/lessons/06-Objects/tests/05-nullDeleter.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { nullDeleter } from "../05-nullDeleter.js";
 import {
   noNull,
@@ -14,27 +13,27 @@ import {
 
 describe("#5: nullDeleter", () => {
   it("returns an object", () => {
-    expect(nullDeleter(noNull)).be.an("object");
-    expect(nullDeleter(oneNull)).be.an("object");
-    expect(nullDeleter(multipleNull)).be.an("object");
-    expect(nullDeleter(allNull)).be.an("object");
+    expect(typeof nullDeleter(noNull)).toBe("object");
+    expect(typeof nullDeleter(oneNull)).toBe("object");
+    expect(typeof nullDeleter(multipleNull)).toBe("object");
+    expect(typeof nullDeleter(allNull)).toBe("object");
   });
 
   it("should handle an empty object", () => {
     const result = nullDeleter({});
-    expect(result).to.deep.equal({});
+    expect(result).toEqual({});
   });
 
   describe("returns the input untouched", () => {
     it("when it has no null key-value pairs", () => {
-      expect(nullDeleter(noNull)).to.eql(noNull);
+      expect(nullDeleter(noNull)).toEqual(noNull);
     });
   });
 
   describe("removes all null key-value pairs", () => {
     it("when there's one present", () => {
       const result = nullDeleter(mixedTypes);
-      expect(result).to.deep.equal({
+      expect(result).toEqual({
         num: 1,
         bool: true,
         str: "hello",
@@ -44,25 +43,25 @@ describe("#5: nullDeleter", () => {
     });
 
     it("when there's multiple present", () => {
-      expect(nullDeleter(multipleNull)).to.eql({
+      expect(nullDeleter(multipleNull)).toEqual({
         three: "goodbye",
       });
     });
 
     it("when they're all null values", () => {
-      expect(nullDeleter(allNull)).to.eql({});
+      expect(nullDeleter(allNull)).toEqual({});
     });
   });
 
   describe("BONUS", () => {
     it("should handle nested objects with no null values", () => {
       const result = nullDeleter(noNullsNested);
-      expect(result).to.deep.equal(noNullsNested);
+      expect(result).toEqual(noNullsNested);
     });
 
     it("should handle top-level null values in a nested object", () => {
       const result = nullDeleter(oneNullTopLevel);
-      expect(result).to.deep.equal({
+      expect(result).toEqual({
         one: 1,
         three: "goodbye",
         nested: noNull,
@@ -71,7 +70,7 @@ describe("#5: nullDeleter", () => {
 
     it("should handle nested objects with null values", () => {
       const result = nullDeleter(oneNullNested);
-      expect(result).to.deep.equal({
+      expect(result).toEqual({
         ...noNull,
         nested: { one: 1, three: "goodbye" },
       });
@@ -79,7 +78,7 @@ describe("#5: nullDeleter", () => {
 
     it("should handle completely null nested objects", () => {
       const result = nullDeleter(allNullsNested);
-      expect(result).to.deep.equal({ nested: {} });
+      expect(result).toEqual({ nested: {} });
     });
   });
 });

--- a/topics/js/lessons/06-Objects/tests/06-onePairObjects.test.js
+++ b/topics/js/lessons/06-Objects/tests/06-onePairObjects.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { onePairObjects } from "../06-onePairObjects.js";
 import {
   singlePair,
@@ -13,26 +12,26 @@ import {
 describe("#6: onePairObjects", () => {
   it("returns an empty array for an empty input object", () => {
     const result = onePairObjects({});
-    expect(result).to.deep.equal([]);
+    expect(result).toEqual([]);
   });
 
   it("returns an array with one object for an input object with one key-value pair", () => {
     const result = onePairObjects(singlePair);
-    expect(result).to.deep.equal([{ one: 1 }]);
+    expect(result).toEqual([{ one: 1 }]);
   });
 
   it("returns an array with multiple objects for an input object with multiple key-value pairs", () => {
     const result = onePairObjects(multipleTopLevelPairs);
-    expect(result).to.deep.equal(multipleTopLevelPairsAns);
+    expect(result).toEqual(multipleTopLevelPairsAns);
   });
 
   it("handles nested objects as values correctly", () => {
     const result = onePairObjects(hasNestedObj);
-    expect(result).to.deep.equal(hasNestedObjAns);
+    expect(result).toEqual(hasNestedObjAns);
   });
 
   it("handles different types of values correctly", () => {
     const result = onePairObjects(mixedTypesObj);
-    expect(result).to.deep.equal(mixedTypesAns);
+    expect(result).toEqual(mixedTypesAns);
   });
 });

--- a/topics/js/lessons/06-Objects/tests/07-objectCombiner.test.js
+++ b/topics/js/lessons/06-Objects/tests/07-objectCombiner.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { objectCombiner } from "../07-objectCombiner.js";
 import {
   hasOverlappingKeys,
@@ -10,34 +9,34 @@ import {
 describe("#7: objectCombiner", () => {
   it("should handle no arguments and return an empty object", () => {
     const result = objectCombiner();
-    expect(result).to.deep.equal({});
+    expect(result).toEqual({});
   });
 
   it("should handle one argument and return the same object", () => {
     const obj1 = { a: 1, b: 2 };
     const result = objectCombiner(obj1);
-    expect(result).to.deep.equal({ a: 1, b: 2 });
+    expect(result).toEqual({ a: 1, b: 2 });
   });
 
   describe("should combine", () => {
     it("two objects without overlapping keys", () => {
       const result = objectCombiner(...noOverlappingKeys);
-      expect(result).to.deep.equal({ a: 1, b: 2, c: 3, d: 4 });
+      expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
     });
 
     it("two objects with overlapping keys", () => {
       const result = objectCombiner(...hasOverlappingKeys);
-      expect(result).to.deep.equal({ a: 1, b: 3, d: 4 });
+      expect(result).toEqual({ a: 1, b: 3, d: 4 });
     });
 
     it("multiple objects without overlapping keys", () => {
       const result = objectCombiner(...multipleNoOverlap);
-      expect(result).to.deep.equal({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
+      expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
     });
 
     it("multiple objects with overlapping keys", () => {
       const result = objectCombiner(...multipleHasOverlap);
-      expect(result).to.deep.equal({ a: 4, b: 5, c: 6 });
+      expect(result).toEqual({ a: 4, b: 5, c: 6 });
     });
   });
 });

--- a/topics/js/lessons/06-Objects/tests/immutableCreator.test.js
+++ b/topics/js/lessons/06-Objects/tests/immutableCreator.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import immutableCreator from "../immutableCreator.js";
 import {
   modifyExistingProperties,
@@ -12,30 +11,30 @@ describe("immutableCreator", function () {
   it("should modify existing properties and add new ones", function () {
     const { originalObj, updates, expected } = modifyExistingProperties;
     const result = immutableCreator(originalObj, updates);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 
   it("should add new properties to the original object", function () {
     const { originalObj, updates, expected } = addNewProperties;
     const result = immutableCreator(originalObj, updates);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 
   it("should return the original object if no updates are provided", function () {
     const { originalObj, updates, expected } = noUpdates;
     const result = immutableCreator(originalObj, updates);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 
   it("should overwrite existing properties with new values", function () {
     const { originalObj, updates, expected } = overwriteProperties;
     const result = immutableCreator(originalObj, updates);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 
   it("should handle an empty original object", function () {
     const { originalObj, updates, expected } = emptyOriginalObject;
     const result = immutableCreator(originalObj, updates);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/topics/js/lessons/06-Objects/tests/modifyProperties.test.js
+++ b/topics/js/lessons/06-Objects/tests/modifyProperties.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import modifyProperties from "../modifyProperties.js";
 import {
   updateExistingProperties,
@@ -12,30 +11,30 @@ describe("modifyProperties", function () {
   it("should update existing properties", function () {
     const { obj, operations, expected } = updateExistingProperties;
     const result = modifyProperties(obj, operations);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 
   it("should add new properties", function () {
     const { obj, operations, expected } = addNewProperties;
     const result = modifyProperties(obj, operations);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 
   it("should delete properties when value is null", function () {
     const { obj, operations, expected } = deleteProperties;
     const result = modifyProperties(obj, operations);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 
   it("should handle multiple operations", function () {
     const { obj, operations, expected } = multipleOperations;
     const result = modifyProperties(obj, operations);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 
   it("should handle empty operations array", function () {
     const { obj, operations, expected } = emptyOperationsArray;
     const result = modifyProperties(obj, operations);
-    expect(result).to.deep.equal(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/topics/js/lessons/10-Classes/tests/01-rectangle.test.js
+++ b/topics/js/lessons/10-Classes/tests/01-rectangle.test.js
@@ -1,54 +1,53 @@
-import { expect } from "chai";
 import Rectangle from "../01-rectangle.js";
 
 describe("#1: Rectangle", () => {
   let myRect, mySquare;
 
-  before(() => {
+  beforeAll(() => {
     myRect = new Rectangle(5, 6);
     mySquare = new Rectangle(10, 10);
   });
 
   it("is a class", () => {
-    expect(myRect instanceof Rectangle).to.be.true;
-    expect(mySquare instanceof Rectangle).to.be.true;
+    expect(myRect instanceof Rectangle).toBe(true);
+    expect(mySquare instanceof Rectangle).toBe(true);
   });
 
   it("has the property `width`", () => {
-    expect(myRect).to.have.property("width");
-    expect(mySquare).to.have.property("width");
+    expect(myRect).toHaveProperty("width");
+    expect(mySquare).toHaveProperty("width");
   });
 
   it("has the property `height`", () => {
-    expect(myRect).to.have.property("height");
-    expect(mySquare).to.have.property("height");
+    expect(myRect).toHaveProperty("height");
+    expect(mySquare).toHaveProperty("height");
   });
 
   it("accepts two number inputs for its length and width", () => {
-    expect(myRect.width).to.equal(5);
-    expect(myRect.height).to.equal(6);
+    expect(myRect.width).toBe(5);
+    expect(myRect.height).toBe(6);
 
-    expect(mySquare.width).to.equal(10);
-    expect(mySquare.height).to.equal(10);
+    expect(mySquare.width).toBe(10);
+    expect(mySquare.height).toBe(10);
   });
 
   it("has the instance method `area`", () => {
-    expect(myRect.area).to.be.a("function");
-    expect(mySquare.area).to.be.a("function");
+    expect(typeof myRect.area).toBe("function");
+    expect(typeof mySquare.area).toBe("function");
   });
 
   it("has the instance method `perimeter`", () => {
-    expect(myRect.perimeter).to.be.a("function");
-    expect(mySquare.perimeter).to.be.a("function");
+    expect(typeof myRect.perimeter).toBe("function");
+    expect(typeof mySquare.perimeter).toBe("function");
   });
 
   it("the instance method `area` correctly returns the area of the rectangle", () => {
-    expect(myRect.area()).to.equal(30);
-    expect(mySquare.area()).to.equal(100);
+    expect(myRect.area()).toBe(30);
+    expect(mySquare.area()).toBe(100);
   });
 
   it("the instance method `perimeter` correctly returns the area of the rectangle", () => {
-    expect(myRect.perimeter()).to.equal(22);
-    expect(mySquare.perimeter()).to.equal(40);
+    expect(myRect.perimeter()).toBe(22);
+    expect(mySquare.perimeter()).toBe(40);
   });
 });

--- a/topics/js/lessons/10-Classes/tests/02-carAndOwner.test.js
+++ b/topics/js/lessons/10-Classes/tests/02-carAndOwner.test.js
@@ -1,70 +1,68 @@
-import { expect } from "chai";
 import { Car, Owner } from "../02-carAndOwner.js";
 
 describe("#2: Car and Owner", () => {
   let myCar, myOwner;
 
-  before(() => {
+  beforeAll(() => {
     myCar = new Car(2008, "Subaru", "Forester", 155000);
     myOwner = new Owner(2008, "Subaru", "Forester", 155000, "John Doe");
   });
 
   describe("Car", () => {
     it("is a class", () => {
-      expect(myCar instanceof Car).to.be.true;
+      expect(myCar instanceof Car).toBe(true);
     });
 
     it("has the number property `year`", () => {
-      expect(myCar).to.have.property("year");
-      expect(myCar.year).to.be.a("number");
+      expect(myCar).toHaveProperty("year");
+      expect(typeof myCar.year).toBe("number");
     });
 
     it("has the string property `make`", () => {
-      expect(myCar).to.have.property("make");
-      expect(myCar.make).to.be.a("string");
+      expect(myCar).toHaveProperty("make");
+      expect(typeof myCar.make).toBe("string");
     });
 
     it("has the string property `model`", () => {
-      expect(myCar).to.have.property("model");
-      expect(myCar.model).to.be.a("string");
+      expect(myCar).toHaveProperty("model");
+      expect(typeof myCar.model).toBe("string");
     });
 
     it("has the number property `miles`", () => {
-      expect(myCar).to.have.property("miles");
-      expect(myCar.miles).to.be.a("number");
+      expect(myCar).toHaveProperty("miles");
+      expect(typeof myCar.miles).toBe("number");
     });
 
     describe("the instance method `details`", () => {
       it("is a function", () => {
-        expect(myCar.details).to.be.a("function");
+        expect(typeof myCar.details).toBe("function");
       });
 
       it("returns the correct string", () => {
         let result = myCar.details();
-        expect(result)
-          .to.be.a("string")
-          .that.includes("2008 Subaru Forester @ 155000");
+        expect(typeof result).toBe("string");
+        expect(result).toContain("2008 Subaru Forester @ 155000");
       });
     });
   });
 
   describe("Owner", () => {
     it("is a class", () => {
-      expect(myOwner instanceof Owner).to.be.true;
+      expect(myOwner instanceof Owner).toBe(true);
     });
 
     it("is a subclass of Car", () => {
-      expect(Object.getPrototypeOf(Owner.prototype)).to.equal(Car.prototype);
-      expect(myOwner instanceof Car).to.be.true;
+      expect(Object.getPrototypeOf(Owner.prototype)).toBe(Car.prototype);
+      expect(myOwner instanceof Car).toBe(true);
     });
 
     describe("inherited properties and methods", () => {
       it("inherits `year`, `make`, `model`, `miles` from the Car class", () => {
-        expect(myOwner.year).to.equal(2008);
-        expect(myOwner.make).to.equal("Subaru");
-        expect(myOwner.model).to.equal("Forester");
-        expect(myOwner.miles).to.equal(155000);
-        expect(myOwner.details()).to.include("2008 Subaru Forester @ 155000");
+        expect(myOwner.year).toBe(2008);
+        expect(myOwner.make).toBe("Subaru");
+        expect(myOwner.model).toBe("Forester");
+        expect(myOwner.miles).toBe(155000);
+        expect(myOwner.details()).toContain("2008 Subaru Forester @ 155000");
       });
     });
   });

--- a/topics/js/lessons/11-Data-Structures/tests/linked-list.test.js
+++ b/topics/js/lessons/11-Data-Structures/tests/linked-list.test.js
@@ -1,5 +1,4 @@
-/* eslint-env mocha */
-import { expect } from "chai";
+/* eslint-env jest */
 import { LinkedList, Node } from "../linked-list.js";
 
 describe("A linked list implementation", () => {
@@ -12,50 +11,50 @@ describe("A linked list implementation", () => {
   describe("`Node` class", () => {
     it("should take a value argument in the constructor and define next and previous to be null by default", () => {
       const node = new Node("test");
-      expect(node.value).to.equal("test");
-      expect(node.next).to.equal(null);
-      expect(node.previous).to.equal(null);
+      expect(node.value).toBe("test");
+      expect(node.next).toBe(null);
+      expect(node.previous).toBe(null);
     });
   });
 
   describe("`LinkedList` class", () => {
     it("should take no arguments in the constructor and define head and tail to be null", () => {
-      expect(linkedList.head).to.equal(null);
-      expect(linkedList.tail).to.equal(null);
+      expect(linkedList.head).toBe(null);
+      expect(linkedList.tail).toBe(null);
     });
 
     it("has methods `addToTail`, `removeTail`, and `search`", () => {
-      expect(typeof linkedList.addToTail).to.equal("function");
-      expect(typeof linkedList.removeTail).to.equal("function");
-      expect(typeof linkedList.search).to.equal("function");
+      expect(typeof linkedList.addToTail).toBe("function");
+      expect(typeof linkedList.removeTail).toBe("function");
+      expect(typeof linkedList.search).toBe("function");
     });
 
     describe("`addToTail` method", () => {
       it("should take a value as a parameter", () => {
         // the length of a function returns how many parameters it has
-        expect(linkedList.addToTail.length).to.equal(1);
+        expect(linkedList.addToTail.length).toBe(1);
       });
 
       it("should use `Node` class to add nodes", () => {
         linkedList.addToTail("first");
-        expect(linkedList.tail instanceof Node).to.equal(true);
+        expect(linkedList.tail instanceof Node).toBe(true);
       });
 
       it("should be able to add to tail without removing or overwriting existing nodes", () => {
         linkedList.addToTail("first");
-        expect(linkedList.tail.value).to.equal("first");
+        expect(linkedList.tail.value).toBe("first");
 
         linkedList.addToTail("second");
-        expect(linkedList.tail.value).to.equal("second");
-        expect(linkedList.tail.previous.value).to.equal("first");
+        expect(linkedList.tail.value).toBe("second");
+        expect(linkedList.tail.previous.value).toBe("first");
       });
 
       it("if the linked list consists of a single node after adding to tail, that node should be both the head and the tail", () => {
         linkedList.addToTail("only");
-        expect(linkedList.head.value).to.equal("only");
-        expect(linkedList.head).to.equal(linkedList.tail);
-        expect(linkedList.head.next).to.equal(null);
-        expect(linkedList.head.previous).to.equal(null);
+        expect(linkedList.head.value).toBe("only");
+        expect(linkedList.head).toBe(linkedList.tail);
+        expect(linkedList.head.next).toBe(null);
+        expect(linkedList.head.previous).toBe(null);
       });
     });
 
@@ -64,9 +63,9 @@ describe("A linked list implementation", () => {
         linkedList.addToTail("first");
         linkedList.addToTail("second");
         linkedList.addToTail("third");
-        expect(linkedList.removeTail()).to.equal("third");
-        expect(linkedList.removeTail()).to.equal("second");
-        expect(linkedList.removeTail()).to.equal("first");
+        expect(linkedList.removeTail()).toBe("third");
+        expect(linkedList.removeTail()).toBe("second");
+        expect(linkedList.removeTail()).toBe("first");
       });
 
       it("should reassign the `tail` after the current tail node is removed", () => {
@@ -75,10 +74,10 @@ describe("A linked list implementation", () => {
         linkedList.addToTail("third");
 
         linkedList.removeTail(); // remove 'third'
-        expect(linkedList.tail.value).to.equal("second");
+        expect(linkedList.tail.value).toBe("second");
 
         linkedList.removeTail(); // remove 'second'
-        expect(linkedList.tail.value).to.equal("first");
+        expect(linkedList.tail.value).toBe("first");
       });
 
       it("should make sure the `next` of any newly appointed tail is null", () => {
@@ -87,16 +86,16 @@ describe("A linked list implementation", () => {
         linkedList.addToTail("third");
 
         linkedList.removeTail();
-        expect(linkedList.tail.value).to.equal("second");
-        expect(linkedList.tail.next).to.equal(null);
+        expect(linkedList.tail.value).toBe("second");
+        expect(linkedList.tail.next).toBe(null);
 
         linkedList.removeTail();
-        expect(linkedList.tail.value).to.equal("first");
-        expect(linkedList.tail.next).to.equal(null);
+        expect(linkedList.tail.value).toBe("first");
+        expect(linkedList.tail.next).toBe(null);
       });
 
       it("returns null if there is no tail to remove (ie: the list is empty, or all nodes have been removed)", () => {
-        expect(linkedList.removeTail()).to.equal(null);
+        expect(linkedList.removeTail()).toBe(null);
 
         linkedList.addToTail("first");
         linkedList.addToTail("second");
@@ -104,7 +103,7 @@ describe("A linked list implementation", () => {
         linkedList.removeTail();
         linkedList.removeTail();
         linkedList.removeTail();
-        expect(linkedList.removeTail()).to.equal(null);
+        expect(linkedList.removeTail()).toBe(null);
       });
     });
 
@@ -117,9 +116,9 @@ describe("A linked list implementation", () => {
         linkedList.addToTail("one");
         linkedList.addToTail("two");
         linkedList.addToTail("three");
-        expect(linkedList.search("one")).to.equal("one");
-        expect(linkedList.search("sdd")).to.equal(null);
-        expect(linkedList.search("three")).to.equal("three");
+        expect(linkedList.search("one")).toBe("one");
+        expect(linkedList.search("sdd")).toBe(null);
+        expect(linkedList.search("three")).toBe("three");
       });
 
       it("should be able to take functions as search inputs", () => {
@@ -128,7 +127,7 @@ describe("A linked list implementation", () => {
         const foundNode = linkedList.search((nodeValue) => {
           return nodeValue === "two";
         });
-        expect(foundNode).to.equal("two");
+        expect(foundNode).toBe("two");
       });
 
       // This spec demonstrates the utility of the previous spec.
@@ -149,52 +148,52 @@ describe("A linked list implementation", () => {
         const foundNode1 = linkedList.search((userNode) => {
           return userNode.name === "Nimit";
         });
-        expect(foundNode1.email).to.equal("nimit@fs.com");
+        expect(foundNode1.email).toBe("nimit@fs.com");
 
         const foundNode2 = linkedList.search((userNode) => {
           return userNode.email === "david@fs.com";
         });
-        expect(foundNode2.city).to.equal("New York");
+        expect(foundNode2.city).toBe("New York");
 
         const foundNode3 = linkedList.search((userNode) => {
           return userNode.city === "Mountain View";
         });
-        expect(foundNode3.name).to.equal("Paul");
+        expect(foundNode3.name).toBe("Paul");
       });
     });
 
     describe("`head` functionality, (doubly linked)", () => {
       it("has the functions `addToHead`, `removeHead`", () => {
-        expect(typeof linkedList.addToHead).to.equal("function");
-        expect(typeof linkedList.removeHead).to.equal("function");
+        expect(typeof linkedList.addToHead).toBe("function");
+        expect(typeof linkedList.removeHead).toBe("function");
       });
 
       describe("`addToHead` method", () => {
         it("should take a value as a parameter", () => {
           // the length of a function returns how many parameters it has
-          expect(linkedList.addToHead.length).to.equal(1);
+          expect(linkedList.addToHead.length).toBe(1);
         });
 
         it("should use `Node` class to add nodes", () => {
           linkedList.addToHead("first");
-          expect(linkedList.head instanceof Node).to.equal(true);
+          expect(linkedList.head instanceof Node).toBe(true);
         });
 
         it("should be able to add to head without removing or overwriting existing nodes", () => {
           linkedList.addToHead("first");
-          expect(linkedList.head.value).to.equal("first");
+          expect(linkedList.head.value).toBe("first");
 
           linkedList.addToHead("zeroth");
-          expect(linkedList.head.value).to.equal("zeroth");
-          expect(linkedList.head.next.value).to.equal("first");
+          expect(linkedList.head.value).toBe("zeroth");
+          expect(linkedList.head.next.value).toBe("first");
         });
 
         it("if the linked list consists of a single node after adding to head, that node should be both the head and the tail", () => {
           linkedList.addToHead("only");
-          expect(linkedList.head.value).to.equal("only");
-          expect(linkedList.head).to.equal(linkedList.tail);
-          expect(linkedList.head.next).to.equal(null);
-          expect(linkedList.head.previous).to.equal(null);
+          expect(linkedList.head.value).toBe("only");
+          expect(linkedList.head).toBe(linkedList.tail);
+          expect(linkedList.head.next).toBe(null);
+          expect(linkedList.head.previous).toBe(null);
         });
       });
 
@@ -203,9 +202,9 @@ describe("A linked list implementation", () => {
           linkedList.addToTail("first");
           linkedList.addToTail("second");
           linkedList.addToTail("third");
-          expect(linkedList.removeHead()).to.equal("first");
-          expect(linkedList.removeHead()).to.equal("second");
-          expect(linkedList.removeHead()).to.equal("third");
+          expect(linkedList.removeHead()).toBe("first");
+          expect(linkedList.removeHead()).toBe("second");
+          expect(linkedList.removeHead()).toBe("third");
         });
 
         it("should reassign the `head` after the current head node is removed", () => {
@@ -214,10 +213,10 @@ describe("A linked list implementation", () => {
           linkedList.addToTail("third");
 
           linkedList.removeHead(); // remove 'first'
-          expect(linkedList.head.value).to.equal("second");
+          expect(linkedList.head.value).toBe("second");
 
           linkedList.removeHead(); // remove 'second'
-          expect(linkedList.head.value).to.equal("third");
+          expect(linkedList.head.value).toBe("third");
         });
 
         it("should make sure the `previous` of any newly appointed head is null", () => {
@@ -226,16 +225,16 @@ describe("A linked list implementation", () => {
           linkedList.addToTail("third");
 
           linkedList.removeHead();
-          expect(linkedList.head.value).to.equal("second");
-          expect(linkedList.head.previous).to.equal(null);
+          expect(linkedList.head.value).toBe("second");
+          expect(linkedList.head.previous).toBe(null);
 
           linkedList.removeHead();
-          expect(linkedList.head.value).to.equal("third");
-          expect(linkedList.head.previous).to.equal(null);
+          expect(linkedList.head.value).toBe("third");
+          expect(linkedList.head.previous).toBe(null);
         });
 
         it("returns null if there is no head to remove (ie: the list is empty, or all nodes have been removed)", () => {
-          expect(linkedList.removeHead()).to.equal(null);
+          expect(linkedList.removeHead()).toBe(null);
 
           linkedList.addToTail("first");
           linkedList.addToTail("second");
@@ -243,14 +242,14 @@ describe("A linked list implementation", () => {
           linkedList.removeHead();
           linkedList.removeHead();
           linkedList.removeHead();
-          expect(linkedList.removeHead()).to.equal(null);
+          expect(linkedList.removeHead()).toBe(null);
         });
 
         it("should reset head and tail to null when last node is removed", () => {
           linkedList.addToTail("first");
           linkedList.removeHead();
-          expect(linkedList.head).to.equal(null);
-          expect(linkedList.tail).to.equal(null);
+          expect(linkedList.head).toBe(null);
+          expect(linkedList.tail).toBe(null);
         });
       });
     });

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -9,7 +9,7 @@
     "test:jest": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config ./jest.config.cjs --runInBand",
     "test:01": "npm run test:jest -- lessons/01-Values-and-Data-Types/01-valuesTypes.test.js",
     "test:02": "npm run test:jest -- lessons/02-Conditionals/tests",
-    "test:03": "mocha './lessons/03-Methods-and-Functions/tests/**.js'",
+    "test:03": "npm run test:jest -- lessons/03-Methods-and-Functions/tests",
     "test:04": "mocha './lessons/04-Arrays-and-Loops/tests/**.js'",
     "test:05": "mocha './lessons/05-Callbacks-Iterators/tests/**.js'",
     "test:06": "mocha './lessons/06-Objects/tests/**.js'",

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -17,7 +17,7 @@
     "test:08": "mocha './lessons/08-Async-Await-APIs/tests/**.js'",
     "server:08": "mocha './lessons/08-Async-Await-APIs/server/tests/**.js'",
     "test:09": "mocha './lessons/09-Recursion/tests/**.js'",
-    "test:10": "mocha './lessons/10-Classes/tests/**.js'",
+    "test:10": "npm run test:jest -- lessons/10-Classes/tests",
     "test:11": "mocha './lessons/11-Data-Structures/tests/**.js'",
     "test:projects": "mocha './projects/**/tests/**.js'",
     "test:twitter": "mocha './projects/Twitter/tests/**.js'"

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -19,7 +19,7 @@
     "test:09": "mocha './lessons/09-Recursion/tests/**.js'",
     "test:10": "npm run test:jest -- lessons/10-Classes/tests",
     "test:11": "npm run test:jest -- lessons/11-Data-Structures/tests",
-    "test:projects": "mocha './projects/**/tests/**.js'",
-    "test:twitter": "mocha './projects/Twitter/tests/**.js'"
+    "test:projects": "npm run test:jest -- projects",
+    "test:twitter": "npm run test:jest -- projects/Twitter/tests"
   }
 }

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -8,7 +8,7 @@
     "test": "npm run test:01 && npm run test:02 && npm run test:03 && npm run test:04 && npm run test:05 && npm run test:06 && npm run test:07 && npm run test:08 && npm run server:08 && npm run test:09 && npm run test:10 && npm run test:11 && npm run test:projects",
     "test:jest": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config ./jest.config.cjs --runInBand",
     "test:01": "npm run test:jest -- lessons/01-Values-and-Data-Types/01-valuesTypes.test.js",
-    "test:02": "mocha './lessons/02-Conditionals/tests/**.js'",
+    "test:02": "npm run test:jest -- lessons/02-Conditionals/tests",
     "test:03": "mocha './lessons/03-Methods-and-Functions/tests/**.js'",
     "test:04": "mocha './lessons/04-Arrays-and-Loops/tests/**.js'",
     "test:05": "mocha './lessons/05-Callbacks-Iterators/tests/**.js'",

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -18,7 +18,7 @@
     "server:08": "mocha './lessons/08-Async-Await-APIs/server/tests/**.js'",
     "test:09": "mocha './lessons/09-Recursion/tests/**.js'",
     "test:10": "npm run test:jest -- lessons/10-Classes/tests",
-    "test:11": "mocha './lessons/11-Data-Structures/tests/**.js'",
+    "test:11": "npm run test:jest -- lessons/11-Data-Structures/tests",
     "test:projects": "mocha './projects/**/tests/**.js'",
     "test:twitter": "mocha './projects/Twitter/tests/**.js'"
   }

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -10,7 +10,7 @@
     "test:01": "npm run test:jest -- lessons/01-Values-and-Data-Types/01-valuesTypes.test.js",
     "test:02": "npm run test:jest -- lessons/02-Conditionals/tests",
     "test:03": "npm run test:jest -- lessons/03-Methods-and-Functions/tests",
-    "test:04": "mocha './lessons/04-Arrays-and-Loops/tests/**.js'",
+    "test:04": "npm run test:jest -- lessons/04-Arrays-and-Loops/tests",
     "test:05": "mocha './lessons/05-Callbacks-Iterators/tests/**.js'",
     "test:06": "mocha './lessons/06-Objects/tests/**.js'",
     "test:07": "mocha './lessons/07-Adv-Objects/tests/**.js'",

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -12,7 +12,7 @@
     "test:03": "npm run test:jest -- lessons/03-Methods-and-Functions/tests",
     "test:04": "npm run test:jest -- lessons/04-Arrays-and-Loops/tests",
     "test:05": "mocha './lessons/05-Callbacks-Iterators/tests/**.js'",
-    "test:06": "mocha './lessons/06-Objects/tests/**.js'",
+    "test:06": "npm run test:jest -- lessons/06-Objects/tests",
     "test:07": "mocha './lessons/07-Adv-Objects/tests/**.js'",
     "test:08": "mocha './lessons/08-Async-Await-APIs/tests/**.js'",
     "server:08": "mocha './lessons/08-Async-Await-APIs/server/tests/**.js'",

--- a/topics/js/projects/Twitter/tests/01-maxCharCount.test.js
+++ b/topics/js/projects/Twitter/tests/01-maxCharCount.test.js
@@ -1,11 +1,10 @@
 import maxCharCount from "../01-maxCharCount.js";
-import { expect } from "chai";
 
 describe("#1: maxCharCount", () => {
   it("returns a string", () => {
     const testStr = "Test string.";
     const result = maxCharCount(testStr);
-    expect(result).to.be.a("string");
+    expect(typeof result).toBe("string");
   });
 
   describe("returns the string untouched", () => {
@@ -13,7 +12,7 @@ describe("#1: maxCharCount", () => {
       const shortStr = "This is a short test text tweet under 280 characters";
       const result = maxCharCount(shortStr);
 
-      expect(result).to.equal(shortStr);
+      expect(result).toBe(shortStr);
     });
 
     it("if the input is exactly 280 characters", () => {
@@ -21,7 +20,7 @@ describe("#1: maxCharCount", () => {
         "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat mas";
 
       const result = maxCharCount(twoEighty);
-      expect(result).to.equal(twoEighty);
+      expect(result).toBe(twoEighty);
     });
   });
 
@@ -32,6 +31,6 @@ describe("#1: maxCharCount", () => {
       "Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts. Separated they live in Bookmarksgrove right at the coast of the Semantics, a large language ocean. A small river named Duden flows by their place and supplies it w";
 
     const result = maxCharCount(fourHundred);
-    expect(result).to.equal(expected);
+    expect(result).toBe(expected);
   });
 });


### PR DESCRIPTION
## Description

- Converted straightforward Chai assertion suites to Jest matchers for lessons 02, 03, 04, 06, 10, and 11.
- Converted the Twitter project test to Jest and routed `test:projects` / `test:twitter` through the Jest helper.
- Preserved one lesson/concern per commit to keep any failures easy to isolate.
- Left mock-heavy, async/server, and legacy Mocha cleanup work for follow-up issues.

## Testing

At root:

- `npm run test:js`
- `npm run test:projects`
- `npm run test:twitter`

## Issues

Closes #175  
Parent #173