### PR TITLE
CODE-176 Convert sinon parts to jest mocks spies

### DIFF
--- a/topics/js/lessons/05-Callbacks-Iterators/tests/01-positiveNegatives.test.js
+++ b/topics/js/lessons/05-Callbacks-Iterators/tests/01-positiveNegatives.test.js
@@ -1,18 +1,44 @@
-import { expect } from "chai";
-import sinon from "sinon";
+import { jest } from "@jest/globals";
 import { a, b, c, d, e, testArr } from "../data/positiveNegatives.data.js";
 import { multiplyNums, numType } from "../01-positivesNegatives.js";
+
+const getNumTypeCases = () => {
+  const abSpy = jest.fn(multiplyNums);
+  const acSpy = jest.fn(multiplyNums);
+  const adSpy = jest.fn(multiplyNums);
+  const aeSpy = jest.fn(multiplyNums);
+  const cbSpy = jest.fn(multiplyNums);
+  const cdSpy = jest.fn(multiplyNums);
+  const ebSpy = jest.fn(multiplyNums);
+
+  return {
+    abSpy,
+    acSpy,
+    adSpy,
+    aeSpy,
+    cbSpy,
+    cdSpy,
+    ebSpy,
+    abMult: numType(a, b, abSpy),
+    acMult: numType(a, c, acSpy),
+    adMult: numType(a, d, adSpy),
+    aeMult: numType(a, e, aeSpy),
+    cbMult: numType(c, b, cbSpy),
+    cdMult: numType(c, d, cdSpy),
+    ebMult: numType(e, b, ebSpy),
+  };
+};
 
 describe("#1: Positives & Negatives", () => {
   describe("multiplyNums", () => {
     it("is a function", () => {
-      expect(multiplyNums).to.be.a("function");
+      expect(typeof multiplyNums).toBe("function");
     });
 
     it("returns a number", () => {
       for (const num1 of testArr) {
         for (const num2 of testArr) {
-          expect(multiplyNums(num1, num2)).to.be.a("number");
+          expect(typeof multiplyNums(num1, num2)).toBe("number");
         }
       }
     });
@@ -20,88 +46,79 @@ describe("#1: Positives & Negatives", () => {
 
   describe("numType", () => {
     it("is a function", () => {
-      expect(numType).to.be.a("function");
+      expect(typeof numType).toBe("function");
     });
 
-    const abSpy = sinon.spy(multiplyNums);
-    const acSpy = sinon.spy(multiplyNums);
-    const adSpy = sinon.spy(multiplyNums);
-    const aeSpy = sinon.spy(multiplyNums);
-    const cbSpy = sinon.spy(multiplyNums);
-    const cdSpy = sinon.spy(multiplyNums);
-    const ebSpy = sinon.spy(multiplyNums);
-
-    const abMult = numType(a, b, abSpy);
-    const acMult = numType(a, c, acSpy);
-    const adMult = numType(a, d, adSpy);
-    const aeMult = numType(a, e, aeSpy);
-    const cbMult = numType(c, b, cbSpy);
-    const cdMult = numType(c, d, cdSpy);
-    const ebMult = numType(e, b, ebSpy);
-
     it("runs the callback function using both of numTypes number inputs", () => {
-      const abInputsCorrect = abSpy.calledWith(a, b);
-      const acInputsCorrect = acSpy.calledWith(a, c);
-      const adInputsCorrect = adSpy.calledWith(a, d);
-      const aeInputsCorrect = aeSpy.calledWith(a, e);
-      const cbInputsCorrect = cbSpy.calledWith(c, b);
-      const cdInputsCorrect = cdSpy.calledWith(c, d);
-      const ebInputsCorrect = ebSpy.calledWith(e, b);
+      const { abSpy, acSpy, adSpy, aeSpy, cbSpy, cdSpy, ebSpy } =
+        getNumTypeCases();
 
-      expect(abInputsCorrect).to.be.true;
-      expect(acInputsCorrect).to.be.true;
-      expect(adInputsCorrect).to.be.true;
-      expect(aeInputsCorrect).to.be.true;
-      expect(cbInputsCorrect).to.be.true;
-      expect(cdInputsCorrect).to.be.true;
-      expect(ebInputsCorrect).to.be.true;
+      expect(abSpy).toHaveBeenCalledWith(a, b);
+      expect(acSpy).toHaveBeenCalledWith(a, c);
+      expect(adSpy).toHaveBeenCalledWith(a, d);
+      expect(aeSpy).toHaveBeenCalledWith(a, e);
+      expect(cbSpy).toHaveBeenCalledWith(c, b);
+      expect(cdSpy).toHaveBeenCalledWith(c, d);
+      expect(ebSpy).toHaveBeenCalledWith(e, b);
     });
 
     describe("when a times b is positive", () => {
       it("runs the multiplyNums callback only once", () => {
-        expect(abSpy.calledOnce).to.be.true;
-        expect(cdSpy.calledOnce).to.be.true;
+        const { abSpy, cdSpy } = getNumTypeCases();
+
+        expect(abSpy).toHaveBeenCalledTimes(1);
+        expect(cdSpy).toHaveBeenCalledTimes(1);
       });
 
       it("returns the correct report string", () => {
-        expect(abMult).to.be.a("string");
-        expect(cdMult).to.be.a("string");
+        const { abMult, cdMult } = getNumTypeCases();
 
-        expect(abMult).to.include(`${a} times ${b}`);
-        expect(cdMult).to.include(`${c} times ${d}`);
+        expect(typeof abMult).toBe("string");
+        expect(typeof cdMult).toBe("string");
+
+        expect(abMult).toContain(`${a} times ${b}`);
+        expect(cdMult).toContain(`${c} times ${d}`);
       });
     });
 
     describe("when a times b is negative", () => {
       it("runs the multiplyNums callback twice", () => {
-        expect(acSpy.calledTwice).to.be.true;
-        expect(adSpy.calledTwice).to.be.true;
-        expect(cbSpy.calledTwice).to.be.true;
+        const { acSpy, adSpy, cbSpy } = getNumTypeCases();
+
+        expect(acSpy).toHaveBeenCalledTimes(2);
+        expect(adSpy).toHaveBeenCalledTimes(2);
+        expect(cbSpy).toHaveBeenCalledTimes(2);
       });
 
       it("returns the correct report string", () => {
-        expect(acMult).to.be.a("string");
-        expect(adMult).to.be.a("string");
-        expect(cbMult).to.be.a("string");
+        const { acMult, adMult, cbMult } = getNumTypeCases();
 
-        expect(acMult).to.include(`${a} times ${c}`);
-        expect(adMult).to.include(`${a} times ${d}`);
-        expect(cbMult).to.include(`${c} times ${b}`);
+        expect(typeof acMult).toBe("string");
+        expect(typeof adMult).toBe("string");
+        expect(typeof cbMult).toBe("string");
+
+        expect(acMult).toContain(`${a} times ${c}`);
+        expect(adMult).toContain(`${a} times ${d}`);
+        expect(cbMult).toContain(`${c} times ${b}`);
       });
     });
 
     describe("when a times b is zero", () => {
       it("runs the multiplyNums callback twice", () => {
-        expect(aeSpy.calledTwice).to.be.true;
-        expect(ebSpy.calledTwice).to.be.true;
+        const { aeSpy, ebSpy } = getNumTypeCases();
+
+        expect(aeSpy).toHaveBeenCalledTimes(2);
+        expect(ebSpy).toHaveBeenCalledTimes(2);
       });
 
       it("returns the correct report string", () => {
-        expect(aeMult).to.be.a("string");
-        expect(ebMult).to.be.a("string");
+        const { aeMult, ebMult } = getNumTypeCases();
 
-        expect(aeMult).to.include(`${a} times ${e} is zero`);
-        expect(ebMult).to.include(`${e} times ${b} is zero`);
+        expect(typeof aeMult).toBe("string");
+        expect(typeof ebMult).toBe("string");
+
+        expect(aeMult).toContain(`${a} times ${e} is zero`);
+        expect(ebMult).toContain(`${e} times ${b} is zero`);
       });
     });
   });

--- a/topics/js/lessons/05-Callbacks-Iterators/tests/02-startingCapsOnly.test.js
+++ b/topics/js/lessons/05-Callbacks-Iterators/tests/02-startingCapsOnly.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import {
   startCapWords,
   noCapWords,
@@ -9,22 +8,22 @@ import { startingCapsOnly } from "../02-startingCapsOnly.js";
 
 describe("#2: startingCapsOnly", () => {
   it("returns an array", () => {
-    expect(startingCapsOnly(startCapWords)).to.be.an("array");
-    expect(startingCapsOnly(noCapWords)).to.be.an("array");
-    expect(startingCapsOnly(capsNotAtStart)).to.be.an("array");
-    expect(startingCapsOnly(mixedWords)).to.be.an("array");
+    expect(Array.isArray(startingCapsOnly(startCapWords))).toBe(true);
+    expect(Array.isArray(startingCapsOnly(noCapWords))).toBe(true);
+    expect(Array.isArray(startingCapsOnly(capsNotAtStart))).toBe(true);
+    expect(Array.isArray(startingCapsOnly(mixedWords))).toBe(true);
   });
 
   it("removes no words if all words start with a capital letter", () => {
-    expect(startingCapsOnly(startCapWords)).to.eql(startCapWords);
+    expect(startingCapsOnly(startCapWords)).toEqual(startCapWords);
   });
 
   it("removes all words that don't start with a capital letter", () => {
-    expect(startingCapsOnly(noCapWords)).to.eql([]);
-    expect(startingCapsOnly(capsNotAtStart)).to.eql([]);
+    expect(startingCapsOnly(noCapWords)).toEqual([]);
+    expect(startingCapsOnly(capsNotAtStart)).toEqual([]);
   });
 
   it("removes words that don't start with a capital letter from a mixed array", () => {
-    expect(startingCapsOnly(mixedWords)).to.eql(startCapWords);
+    expect(startingCapsOnly(mixedWords)).toEqual(startCapWords);
   });
 });

--- a/topics/js/lessons/05-Callbacks-Iterators/tests/03-functionRunner.test.js
+++ b/topics/js/lessons/05-Callbacks-Iterators/tests/03-functionRunner.test.js
@@ -1,5 +1,4 @@
-import { expect } from "chai";
-import sinon from "sinon";
+import { jest } from "@jest/globals";
 import {
   numDoubler,
   numsArrInput,
@@ -10,95 +9,127 @@ import {
 } from "../data/functionRunner.data.js";
 import functionRunner from "../03-functionRunner.js";
 
-describe("#3: functionRunner", () => {
-  const noRunStr = sinon.spy(strDoubler);
+const getFunctionRunnerCases = () => {
+  const noRunStr = jest.fn(strDoubler);
   const noRunStrResult = functionRunner(strInput, noRunStr, 0);
 
-  const fourRunStrSpy = sinon.spy(strDoubler);
+  const fourRunStrSpy = jest.fn(strDoubler);
   const fourRunStrResult = functionRunner(strInput, fourRunStrSpy, 4);
 
-  const noRunNum = sinon.spy(numDoubler);
+  const noRunNum = jest.fn(numDoubler);
   const noRunResult = functionRunner(numsArrInput, noRunNum, 0);
 
-  const fourRunNumSpy = sinon.spy(numDoubler);
+  const fourRunNumSpy = jest.fn(numDoubler);
   const fourRunNumResult = functionRunner(numsArrInput, fourRunNumSpy, 4);
 
+  return {
+    noRunStr,
+    noRunStrResult,
+    fourRunStrSpy,
+    fourRunStrResult,
+    noRunNum,
+    noRunResult,
+    fourRunNumSpy,
+    fourRunNumResult,
+  };
+};
+
+describe("#3: functionRunner", () => {
   it("is a function", () => {
-    expect(functionRunner).to.be.a("function");
+    expect(typeof functionRunner).toBe("function");
   });
 
   describe("when runCount is less than 1", () => {
     it("the callback doesn't run", () => {
-      expect(noRunStr.callCount).to.equal(0);
-      expect(noRunNum.callCount).to.equal(0);
+      const { noRunStr, noRunNum } = getFunctionRunnerCases();
+
+      expect(noRunStr).not.toHaveBeenCalled();
+      expect(noRunNum).not.toHaveBeenCalled();
     });
 
     it("the inputVal is returned untouched", () => {
-      expect(noRunStrResult).to.equal(strInput);
-      expect(noRunResult).to.eql(numsArrInput);
+      const { noRunStrResult, noRunResult } = getFunctionRunnerCases();
+
+      expect(noRunStrResult).toBe(strInput);
+      expect(noRunResult).toEqual(numsArrInput);
     });
   });
 
   describe("when runCount is 1 or more", () => {
     it("runs the callback runCount number of times", () => {
-      expect(fourRunStrSpy.callCount).to.equal(4);
-      expect(fourRunNumSpy.callCount).to.equal(4);
+      const { fourRunStrSpy, fourRunNumSpy } = getFunctionRunnerCases();
+
+      expect(fourRunStrSpy).toHaveBeenCalledTimes(4);
+      expect(fourRunNumSpy).toHaveBeenCalledTimes(4);
     });
 
     describe("each callback's inputs", () => {
-      const strSpyCallInfo = fourRunStrSpy.getCalls();
-      const numSpyCallInfo = fourRunNumSpy.getCalls();
-
       it("uses inputVal as input for the first callback run", () => {
-        const firstRunStrInput = fourRunStrSpy.getCall(0).args[0];
-        expect(firstRunStrInput).to.eql(strInput);
+        const { fourRunStrSpy, fourRunNumSpy } = getFunctionRunnerCases();
+        const firstRunStrInput = fourRunStrSpy.mock.calls[0][0];
+        expect(firstRunStrInput).toEqual(strInput);
 
-        const firstRunNumInput = fourRunNumSpy.getCall(0).args[0];
-        expect(firstRunNumInput).to.eql(numsArrInput);
+        const firstRunNumInput = fourRunNumSpy.mock.calls[0][0];
+        expect(firstRunNumInput).toEqual(numsArrInput);
       });
 
       it("uses the return of previous callback run as input for the next", () => {
-        for (let run = 1; run < strSpyCallInfo.length; run++) {
-          const lastReturn = strSpyCallInfo[run - 1].returnValue;
-          const currRunArgs = strSpyCallInfo[run].args[0];
+        const { fourRunStrSpy, fourRunNumSpy } = getFunctionRunnerCases();
+        const strSpyCallInfo = fourRunStrSpy.mock;
+        const numSpyCallInfo = fourRunNumSpy.mock;
 
-          expect(lastReturn).to.equal(currRunArgs);
+        for (let run = 1; run < strSpyCallInfo.calls.length; run++) {
+          const lastReturn = strSpyCallInfo.results[run - 1].value;
+          const currRunArgs = strSpyCallInfo.calls[run][0];
+
+          expect(lastReturn).toBe(currRunArgs);
         }
 
-        for (let run = 1; run < numSpyCallInfo.length; run++) {
-          const lastReturn = numSpyCallInfo[run - 1].returnValue;
-          const currRunArgs = numSpyCallInfo[run].args[0];
+        for (let run = 1; run < numSpyCallInfo.calls.length; run++) {
+          const lastReturn = numSpyCallInfo.results[run - 1].value;
+          const currRunArgs = numSpyCallInfo.calls[run][0];
 
-          expect(lastReturn).to.eql(currRunArgs);
+          expect(lastReturn).toEqual(currRunArgs);
         }
       });
 
       it("returns the correct value after each callback run", () => {
-        strSpyCallInfo.forEach((infoObj, callNum) => {
-          const currCallbackResult = infoObj.returnValue;
+        const { fourRunStrSpy, fourRunNumSpy } = getFunctionRunnerCases();
+
+        fourRunStrSpy.mock.results.forEach((result, callNum) => {
+          const currCallbackResult = result.value;
           const currExpectedResult = fourRunsLetter[callNum];
 
-          expect(currCallbackResult).to.equal(currExpectedResult);
+          expect(currCallbackResult).toBe(currExpectedResult);
         });
 
-        numSpyCallInfo.forEach((infoObj, callNum) => {
-          const currCallbackResult = infoObj.returnValue;
+        fourRunNumSpy.mock.results.forEach((result, callNum) => {
+          const currCallbackResult = result.value;
           const currExpectedResult = fourRunsNums[callNum];
 
-          expect(currCallbackResult).to.eql(currExpectedResult);
+          expect(currCallbackResult).toEqual(currExpectedResult);
         });
       });
 
       it("returns the correct final value after all callback runs are complete", () => {
-        const lastStrCallResult =
-          strSpyCallInfo[strSpyCallInfo.length - 1].returnValue;
+        const {
+          fourRunStrSpy,
+          fourRunStrResult,
+          fourRunNumSpy,
+          fourRunNumResult,
+        } = getFunctionRunnerCases();
 
-        expect(lastStrCallResult).to.equal(fourRunStrResult);
+        const lastStrCallResult =
+          fourRunStrSpy.mock.results[fourRunStrSpy.mock.results.length - 1]
+            .value;
+
+        expect(lastStrCallResult).toBe(fourRunStrResult);
 
         const lastNumCallResult =
-          numSpyCallInfo[numSpyCallInfo.length - 1].returnValue;
+          fourRunNumSpy.mock.results[fourRunNumSpy.mock.results.length - 1]
+            .value;
 
-        expect(lastNumCallResult).to.eql(fourRunNumResult);
+        expect(lastNumCallResult).toEqual(fourRunNumResult);
       });
     });
   });

--- a/topics/js/lessons/05-Callbacks-Iterators/tests/04-everyOtherTime.test.js
+++ b/topics/js/lessons/05-Callbacks-Iterators/tests/04-everyOtherTime.test.js
@@ -1,5 +1,4 @@
-import { expect } from "chai";
-import sinon from "sinon";
+import { jest } from "@jest/globals";
 import {
   capitalize,
   wordsArr,
@@ -11,19 +10,19 @@ import {
 import everyOtherTime from "../04-everyOtherTime.js";
 
 describe("#4: everyOtherTime", () => {
-  const capSpy = sinon.spy(capitalize);
-  const cubeSpy = sinon.spy(cubeNum);
-
-  const capResult = everyOtherTime(wordsArr, capSpy);
-  const cubeResult = everyOtherTime(cubeArr, cubeSpy);
-
   it("runs the callback the correct number of times", () => {
-    expect(capSpy.callCount).to.equal(3);
-    expect(cubeSpy.callCount).to.equal(2);
+    const capSpy = jest.fn(capitalize);
+    const cubeSpy = jest.fn(cubeNum);
+
+    everyOtherTime(wordsArr, capSpy);
+    everyOtherTime(cubeArr, cubeSpy);
+
+    expect(capSpy).toHaveBeenCalledTimes(3);
+    expect(cubeSpy).toHaveBeenCalledTimes(2);
   });
 
   it("returns the correct value", () => {
-    expect(capResult).to.eql(cappedArr);
-    expect(cubeResult).to.eql(evenCubed);
+    expect(everyOtherTime(wordsArr, capitalize)).toEqual(cappedArr);
+    expect(everyOtherTime(cubeArr, cubeNum)).toEqual(evenCubed);
   });
 });

--- a/topics/js/lessons/05-Callbacks-Iterators/tests/05-priceTotaler.test.js
+++ b/topics/js/lessons/05-Callbacks-Iterators/tests/05-priceTotaler.test.js
@@ -1,40 +1,34 @@
-import { expect } from "chai";
-import sinon from "sinon";
 import priceTotaler from "../05-priceTotaler.js";
 
 describe("#5: priceTotaler", () => {
-  const nySpy = sinon.spy(priceTotaler);
-  const njSpy = sinon.spy(priceTotaler);
-  const ctSpy = sinon.spy(priceTotaler);
-
-  const nyTotaler = nySpy("NY");
-  const njTotaler = njSpy("NJ");
-  const ctTotaler = ctSpy("CT");
+  const nyTotaler = priceTotaler("NY");
+  const njTotaler = priceTotaler("NJ");
+  const ctTotaler = priceTotaler("CT");
 
   const nyResult = nyTotaler(1000);
   const njResult = njTotaler(1000);
   const ctResult = ctTotaler(1000);
 
   it("returns a function", () => {
-    expect(nyTotaler).to.be.a("function");
-    expect(njTotaler).to.be.a("function");
-    expect(ctTotaler).to.be.a("function");
+    expect(typeof nyTotaler).toBe("function");
+    expect(typeof njTotaler).toBe("function");
+    expect(typeof ctTotaler).toBe("function");
   });
 
   describe("the returned function correctly calculates the final price for", () => {
     it("NY", () => {
-      expect(nyResult).to.be.a("number");
-      expect(nyResult).to.equal(1095.405);
+      expect(typeof nyResult).toBe("number");
+      expect(nyResult).toBe(1095.405);
     });
 
     it("NJ", () => {
-      expect(njResult).to.be.a("number");
-      expect(njResult).to.equal(1109.5625);
+      expect(typeof njResult).toBe("number");
+      expect(njResult).toBe(1109.5625);
     });
 
     it("CT", () => {
-      expect(ctResult).to.be.a("number");
-      expect(ctResult).to.equal(1102.4);
+      expect(typeof ctResult).toBe("number");
+      expect(ctResult).toBe(1102.4);
     });
   });
 });

--- a/topics/js/lessons/05-Callbacks-Iterators/tests/06-callbackConveyor.test.js
+++ b/topics/js/lessons/05-Callbacks-Iterators/tests/06-callbackConveyor.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import {
   addTen,
   minusTwenty,
@@ -9,16 +8,16 @@ import callbackConveyor from "../06-callbackConveyor.js";
 describe("#6: callbackConveyor", () => {
   it("returns the correct result from one callback", () => {
     const oneResult = callbackConveyor(0, [addTen]);
-    expect(oneResult).to.equal(10);
+    expect(oneResult).toBe(10);
   });
 
   it("returns the correct chained result from two callbacks", () => {
     const oneResult = callbackConveyor(0, [minusTwenty, addTen]);
-    expect(oneResult).to.equal(-10);
+    expect(oneResult).toBe(-10);
   });
   it("returns the correct chained result from three callbacks", () => {
     const oneResult = callbackConveyor(0, [minusTwenty, multiplyThree, addTen]);
 
-    expect(oneResult).to.equal(-50);
+    expect(oneResult).toBe(-50);
   });
 });

--- a/topics/js/lessons/07-Adv-Objects/tests/01-transformObjectVals.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/01-transformObjectVals.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { transformObjectVals } from "../01-transformObjectVals.js";
 import {
   doubleInput,
@@ -22,38 +21,38 @@ import {
 describe("#1: transformObjectVals", () => {
   it("returns an object", () => {
     const result = transformObjectVals(doubleInput, doubleTransform);
-    expect(result).to.be.an("object");
+    expect(typeof result).toBe("object");
   });
 
   it("returns a different object with same input k-v pairs using an identity function", () => {
     const result = transformObjectVals(nestedObj, identityTransform);
-    expect(result).to.not.equal(nestedObj);
-    expect(result).to.deep.equal(nestedObjExpected);
+    expect(result).not.toBe(nestedObj);
+    expect(result).toEqual(nestedObjExpected);
   });
 
   it("returns a different object with same input k-v pairs using an unmatched type-specific function", () => {
     const result = transformObjectVals(uppercaseInput, numOnlyTransform);
-    expect(result).to.not.equal(uppercaseInput);
-    expect(result).to.deep.equal(uppercaseInput);
+    expect(result).not.toBe(uppercaseInput);
+    expect(result).toEqual(uppercaseInput);
   });
 
   it("transforms numeric values using a doubling function", () => {
     const result = transformObjectVals(doubleInput, doubleTransform);
-    expect(result).to.deep.equal(doubleExpected);
+    expect(result).toEqual(doubleExpected);
   });
 
   it("transforms string values using an uppercase function", () => {
     const result = transformObjectVals(uppercaseInput, toUpperCase);
-    expect(result).to.deep.equal(uppercaseExpected);
+    expect(result).toEqual(uppercaseExpected);
   });
 
   it("negates boolean values using a negation function", () => {
     const result = transformObjectVals(booleanInput, negateBoolean);
-    expect(result).to.deep.equal(booleanExpected);
+    expect(result).toEqual(booleanExpected);
   });
 
   it("correctly handles mixed data types using a type-dependent function", () => {
     const result = transformObjectVals(mixedInput, mixedTransform);
-    expect(result).to.deep.equal(mixedExpected);
+    expect(result).toEqual(mixedExpected);
   });
 });

--- a/topics/js/lessons/07-Adv-Objects/tests/02-propValMap.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/02-propValMap.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { propValMap } from "../02-propValMap.js";
 import {
   basicItems,
@@ -14,26 +13,26 @@ import {
 describe("#2: propValMap", () => {
   it("returns a Map", () => {
     const result = propValMap(basicItems);
-    expect(result).to.be.instanceOf(Map);
+    expect(result).toBeInstanceOf(Map);
   });
 
   it("creates a Map with arrays of values for each unique property", () => {
     const result = propValMap(basicItems);
-    expect(result).to.deep.equal(basicMap);
+    expect(result).toEqual(basicMap);
   });
 
   it("handles objects with mixed properties and maintains value arrays", () => {
     const result = propValMap(mixedItems);
-    expect(result).to.deep.equal(mixedMap);
+    expect(result).toEqual(mixedMap);
   });
 
   it("handles nested objects and arrays within the input objects", () => {
     const result = propValMap(nestedItems);
-    expect(result).to.deep.equal(nestedMap);
+    expect(result).toEqual(nestedMap);
   });
 
   it("returns an empty Map when the input array is empty", () => {
     const result = propValMap(emptyItems);
-    expect(result).to.deep.equal(emptyMap);
+    expect(result).toEqual(emptyMap);
   });
 });

--- a/topics/js/lessons/07-Adv-Objects/tests/03-objectToString.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/03-objectToString.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { objectToString } from "../03-objectToString.js";
 import {
   simpleObj,
@@ -14,31 +13,31 @@ import {
 describe("#3: objectToString", () => {
   it("returns a string", () => {
     const result = objectToString({});
-    expect(result).to.be.a("string");
+    expect(typeof result).toBe("string");
   });
 
   it('should serialize an empty object to "{}"', () => {
     const result = objectToString({});
-    expect(result).to.equal("{}");
+    expect(result).toBe("{}");
   });
 
   it("should serialize a simple object to a JSON string", () => {
     const result = objectToString(simpleObj);
-    expect(result).to.equal(simpleObjAsString);
+    expect(result).toBe(simpleObjAsString);
   });
 
   it("should serialize a nested object to a JSON string", () => {
     const result = objectToString(nestedObj);
-    expect(result).to.equal(nestedObjAsString);
+    expect(result).toBe(nestedObjAsString);
   });
 
   it("should serialize an object with arrays to a JSON string", () => {
     const result = objectToString(arrayWithObjects);
-    expect(result).to.equal(arrayWithObjectsAsString);
+    expect(result).toBe(arrayWithObjectsAsString);
   });
 
   it("should handle an object with special characters correctly", () => {
     const result = objectToString(specialCharsObj);
-    expect(result).to.equal(specialCharsObjAsString);
+    expect(result).toBe(specialCharsObjAsString);
   });
 });

--- a/topics/js/lessons/07-Adv-Objects/tests/04-validateObject.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/04-validateObject.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { validateObject } from "../04-validateObject.js";
 import {
   schema,
@@ -13,51 +12,51 @@ describe("#4: validateObject", () => {
   describe("should return true", () => {
     it("for a valid object", () => {
       const result = validateObject(validObj, schema);
-      expect(result).to.be.true;
+      expect(result).toBe(true);
     });
 
     it("if the input object has extra keys not in the schema", () => {
       const result = validateObject(extraKeysObj, schema);
-      expect(result).to.be.true;
+      expect(result).toBe(true);
     });
 
     it("when the schema object is empty but input object is not", () => {
       const emptySchema = validateObject(incompleteObj, {});
-      expect(emptySchema).to.be.true;
+      expect(emptySchema).toBe(true);
     });
 
     it("when both inputs are empty objects", () => {
       const bothEmpty = validateObject({}, {});
-      expect(bothEmpty).to.be.true;
+      expect(bothEmpty).toBe(true);
     });
   });
 
   describe("should return false", () => {
     it("for an invalid object", () => {
       const result = validateObject(invalidObj, schema);
-      expect(result).to.be.false;
+      expect(result).toBe(false);
     });
 
     it("when the object is missing a required key", () => {
       const result = validateObject(incompleteObj, schema);
-      expect(result).to.be.false;
+      expect(result).toBe(false);
     });
 
     it("when the object has an incorrect type", () => {
       const result = validateObject(wrongTypeObj, schema);
-      expect(result).to.be.false;
+      expect(result).toBe(false);
     });
 
     it("when the input object is empty and schema is not", () => {
       const emptyInput = validateObject({}, schema);
-      expect(emptyInput).to.be.false;
+      expect(emptyInput).toBe(false);
     });
 
     it("should handle objects with boolean values correctly", () => {
       const schemaWithBoolean = { active: "boolean" };
       const validBooleanObj = { active: true };
       const result = validateObject(validBooleanObj, schemaWithBoolean);
-      expect(result).to.be.true;
+      expect(result).toBe(true);
     });
   });
 });

--- a/topics/js/lessons/07-Adv-Objects/tests/05-manageInventory.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/05-manageInventory.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { manageInventory } from "../05-manageInventory.js";
 import {
   itemsWithMultipleEntries,
@@ -15,27 +14,27 @@ import {
 
 describe("manageInventory", () => {
   it("should return an empty object if no items are provided", () => {
-    expect(manageInventory(noItems)).to.deep.equal(expectedEmptyResult);
+    expect(manageInventory(noItems)).toEqual(expectedEmptyResult);
   });
 
   it("should handle cases where there is only one item", () => {
-    expect(manageInventory(singleItem)).to.deep.equal(expectedSingleItemResult);
+    expect(manageInventory(singleItem)).toEqual(expectedSingleItemResult);
   });
 
   it("should handle items with zero quantity", () => {
-    expect(manageInventory(itemsWithZeroQuantity)).to.deep.equal(
+    expect(manageInventory(itemsWithZeroQuantity)).toEqual(
       expectedZeroQuantityResult
     );
   });
 
   it("should correctly aggregate quantities when items have different names", () => {
-    expect(manageInventory(itemsWithDifferentNames)).to.deep.equal(
+    expect(manageInventory(itemsWithDifferentNames)).toEqual(
       expectedDifferentNamesResult
     );
   });
 
   it("should correctly aggregate quantities of each item", () => {
-    expect(manageInventory(itemsWithMultipleEntries)).to.deep.equal(
+    expect(manageInventory(itemsWithMultipleEntries)).toEqual(
       expectedAggregatedQuantities
     );
   });

--- a/topics/js/lessons/07-Adv-Objects/tests/06-keyValidator.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/06-keyValidator.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { keyValidator } from "../06-keyValidator.js";
 import {
   emptyOne,
@@ -14,46 +13,46 @@ import {
 describe("#6: keyValidator", () => {
   describe("returns an empty array", () => {
     it("for empty objects", () => {
-      expect(keyValidator(emptyOne, emptyTwo)).to.deep.equal([]);
+      expect(keyValidator(emptyOne, emptyTwo)).toEqual([]);
     });
 
     describe("when each object has the same keys", () => {
       it("with the same values", () => {
-        expect(keyValidator(twoKeysBase, twoKeysSameVals)).to.deep.equal([]);
+        expect(keyValidator(twoKeysBase, twoKeysSameVals)).toEqual([]);
       });
 
       it("with different values", () => {
-        expect(keyValidator(twoKeysBase, twoKeysDiffVals)).to.deep.equal([]);
+        expect(keyValidator(twoKeysBase, twoKeysDiffVals)).toEqual([]);
       });
     });
 
     it("when baseObj contains all of targetObj's keys and their own", () => {
       const result1 = keyValidator(twoKeysSameVals, oneKey);
-      expect(result1).to.deep.equal([]);
+      expect(result1).toEqual([]);
 
       const result2 = keyValidator(manyKeys, emptyOne);
-      expect(result2).to.deep.equal([]);
+      expect(result2).toEqual([]);
     });
   });
 
   describe("returns an array containing the missing keys", () => {
     it("when baseObj is missing one key", () => {
       const result1 = keyValidator(emptyOne, oneKey);
-      expect(result1).to.deep.equal(["a"]);
+      expect(result1).toEqual(["a"]);
 
       const result2 = keyValidator(oneKey, twoKeysDiffVals);
-      expect(result2).to.deep.equal(["b"]);
+      expect(result2).toEqual(["b"]);
     });
 
     it("when baseObj is missing more than one key", () => {
       const result1 = keyValidator(emptyOne, twoKeysBase);
-      expect(result1).to.deep.equal(["a", "b"]);
+      expect(result1).toEqual(["a", "b"]);
 
       const result2 = keyValidator(emptyTwo, manyKeys);
-      expect(result2).to.deep.equal(["e", "f", "g"]);
+      expect(result2).toEqual(["e", "f", "g"]);
 
       const result3 = keyValidator(twoKeysBase, twoKeysDiffKeys);
-      expect(result3).to.deep.equal(["c", "d"]);
+      expect(result3).toEqual(["c", "d"]);
     });
   });
 });

--- a/topics/js/lessons/07-Adv-Objects/tests/07-mergeConfigs.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/07-mergeConfigs.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { mergeConfigs } from "../07-mergeConfigs.js";
 import {
   defaultThemeConfig,
@@ -15,26 +14,26 @@ import {
 describe("#7: mergeConfigs", () => {
   it("should correctly merge configurations when both objects have unique properties", () => {
     const result = mergeConfigs(defaultApiConfig, customApiConfig);
-    expect(result).to.deep.equal(expectedMergedApiConfig);
+    expect(result).toEqual(expectedMergedApiConfig);
   });
 
   it("should correctly merge default and user configurations with userConfig taking precedence", () => {
     const result = mergeConfigs(defaultThemeConfig, userThemeConfig);
-    expect(result).to.deep.equal(expectedMergedThemeConfig);
+    expect(result).toEqual(expectedMergedThemeConfig);
   });
 
   it('should handle the case where "defaultConfig" is empty and "userConfig" is not', () => {
     const result = mergeConfigs(defaultApiConfig, userConfigEmpty);
-    expect(result).to.deep.equal(defaultApiConfig);
+    expect(result).toEqual(defaultApiConfig);
   });
 
   it('should handle the case where "userConfig" is empty and "defaultConfig" is not', () => {
     const result = mergeConfigs(defaultApiConfig, userConfigEmpty);
-    expect(result).to.deep.equal(defaultApiConfig);
+    expect(result).toEqual(defaultApiConfig);
   });
 
   it("should handle the case where both configs are empty", () => {
     const result = mergeConfigs(defaultConfigEmpty, userConfigEmpty);
-    expect(result).to.deep.equal(expectedEmptyMergedConfig);
+    expect(result).toEqual(expectedEmptyMergedConfig);
   });
 });

--- a/topics/js/lessons/07-Adv-Objects/tests/08-classSorter.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/08-classSorter.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { classSorter } from "../08-classSorter.js";
 import {
   emptyRoster,
@@ -17,38 +16,38 @@ import {
 describe("#8: classSorter", () => {
   it("should return an empty object for an empty roster", () => {
     const sortedClasses = classSorter(emptyRoster);
-    expect(sortedClasses).to.deep.equal({});
+    expect(sortedClasses).toEqual({});
   });
 
   describe("should correctly sort a roster", () => {
     describe("one grade", () => {
       it("only students", () => {
         const sortedClasses = classSorter(onlyStudentsRoster);
-        expect(sortedClasses).to.deep.equal(onlyStudentsExpected);
+        expect(sortedClasses).toEqual(onlyStudentsExpected);
       });
 
       it("only teachers", () => {
         const sortedClasses = classSorter(onlyTeachersRoster);
-        expect(sortedClasses).to.deep.equal(onlyTeachersExpected);
+        expect(sortedClasses).toEqual(onlyTeachersExpected);
       });
 
       it("students and teachers", () => {
         const sortedClasses = classSorter(oneGradeSaTRoster);
-        expect(sortedClasses).to.deep.equal(oneGradeSaTExpected);
+        expect(sortedClasses).toEqual(oneGradeSaTExpected);
       });
     });
 
     describe("two grades", () => {
       it("students and teachers", () => {
         const sortedClasses = classSorter(twoGradeSaTRoster);
-        expect(sortedClasses).to.deep.equal(twoGradeSaTExpected);
+        expect(sortedClasses).toEqual(twoGradeSaTExpected);
       });
     });
 
     describe("multiple grades", () => {
       it("students and teachers", () => {
         const sortedClasses = classSorter(multipleGradeSaTRoster);
-        expect(sortedClasses).to.deep.equal(multipleGradeSaTExpected);
+        expect(sortedClasses).toEqual(multipleGradeSaTExpected);
       });
     });
   });

--- a/topics/js/lessons/07-Adv-Objects/tests/09-findObjectDifferences.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/09-findObjectDifferences.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { findObjectDifferences } from "../09-findObjectDifferences.js";
 import {
   objectA,
@@ -14,30 +13,30 @@ import {
 
 describe("#9: findObjectDifferences", function () {
   it("should find differences between two objects with some differing and some matching properties", function () {
-    expect(findObjectDifferences(objectA, objectB)).to.deep.equal(
+    expect(findObjectDifferences(objectA, objectB)).toEqual(
       expectedDifferencesAB
     );
   });
 
   it("should find differences when one object has additional properties", function () {
-    expect(findObjectDifferences(objectX, objectY)).to.deep.equal(
+    expect(findObjectDifferences(objectX, objectY)).toEqual(
       expectedDifferencesXY
     );
   });
 
   it("should handle cases where both objects are empty", function () {
-    expect(findObjectDifferences(objectEmpty1, objectEmpty2)).to.deep.equal(
+    expect(findObjectDifferences(objectEmpty1, objectEmpty2)).toEqual(
       expectedDifferencesEmpty
     );
   });
 
   it("should handle cases where one object is empty and the other has properties", function () {
-    expect(findObjectDifferences(objectEmpty1, objectY)).to.deep.equal({
+    expect(findObjectDifferences(objectEmpty1, objectY)).toEqual({
       size: [undefined, "M"],
       color: [undefined, "blue"],
       material: [undefined, "cotton"],
     });
-    expect(findObjectDifferences(objectX, objectEmpty2)).to.deep.equal({
+    expect(findObjectDifferences(objectX, objectEmpty2)).toEqual({
       color: ["red", undefined],
       size: ["M", undefined],
     });

--- a/topics/js/lessons/07-Adv-Objects/tests/10-deepClone.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/10-deepClone.test.js
@@ -1,5 +1,4 @@
-import { expect } from "chai";
-import sinon from "sinon";
+import { jest } from "@jest/globals";
 import { deepClone } from "../10-deepClone.js";
 import {
   objNoDate,
@@ -8,35 +7,43 @@ import {
   clonedObjWithDate,
 } from "../data/10-deepClone.data.js";
 
-// Mocking to detect calls to Object.assign and structuredClone
-const objectAssignSpy = sinon.spy(Object, "assign");
-const structuredCloneSpy = sinon.spy(globalThis, "structuredClone");
-
 describe("#10: deepClone", () => {
+  let objectAssignSpy;
+  let structuredCloneSpy;
+
+  beforeEach(() => {
+    objectAssignSpy = jest.spyOn(Object, "assign");
+    structuredCloneSpy = jest.spyOn(globalThis, "structuredClone");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("should return an object", () => {
     const result = deepClone(objNoDate);
-    expect(result).to.be.an("object");
+    expect(typeof result).toBe("object");
   });
 
   it("should correctly clone objects without Date objects", () => {
     const result = deepClone(objNoDate);
-    expect(result).to.deep.equal(clonedObjWithoutDate);
+    expect(result).toEqual(clonedObjWithoutDate);
   });
 
   it("should not mutate the original object", () => {
     const result = deepClone(objNoDate);
-    expect(result).to.not.equal(objNoDate);
-    expect(result).to.deep.equal(clonedObjWithoutDate);
+    expect(result).not.toBe(objNoDate);
+    expect(result).toEqual(clonedObjWithoutDate);
   });
 
   it("should not call Object.assign()", () => {
     deepClone(objNoDate);
-    expect(objectAssignSpy.called).to.be.false;
+    expect(objectAssignSpy).not.toHaveBeenCalled();
   });
 
   it("should not call structuredClone()", () => {
     deepClone(objNoDate);
-    expect(structuredCloneSpy.called).to.be.false;
+    expect(structuredCloneSpy).not.toHaveBeenCalled();
   });
 
   // Makes problem FAR too difficult to solve without recursion
@@ -47,29 +54,25 @@ describe("#10: deepClone", () => {
   //   const obj2 = deepClone(obj1); // Assuming deepClone function is tested here
 
   //   // Check that obj2 is not the same reference as obj1
-  //   expect(obj2).to.not.equal(obj1);
+  //   expect(obj2).not.toBe(obj1);
 
   //   // Check that obj2 deeply equals obj1 (all values are the same)
-  //   expect(obj2).to.deep.equal(obj1);
+  //   expect(obj2).toEqual(obj1);
 
   //   // Further check that nested objects also don't share the same reference
-  //   expect(obj2.b).to.not.equal(obj1.b);
+  //   expect(obj2.b).not.toBe(obj1.b);
   // });
 
   describe("BONUS", () => {
     it("should correctly clone objects with Date objects", () => {
       const result = deepClone(objWithDate);
-      expect(result).to.deep.equal(clonedObjWithDate);
+      expect(result).toEqual(clonedObjWithDate);
     });
 
     it("should correctly clone Date objects and preserve their functionality", () => {
       const result = deepClone(objWithDate);
-      expect(result.date).to.be.instanceOf(Date);
-      expect(result.date.getTime()).to.equal(objWithDate.date.getTime());
+      expect(result.date).toBeInstanceOf(Date);
+      expect(result.date.getTime()).toBe(objWithDate.date.getTime());
     });
   });
 });
-
-// Restore the original implementations after the test
-objectAssignSpy.restore();
-structuredCloneSpy.restore();

--- a/topics/js/lessons/07-Adv-Objects/tests/11-phraseScore.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/11-phraseScore.test.js
@@ -1,5 +1,4 @@
 import { phraseScore } from "../11-phraseScore.js";
-import { expect } from "chai";
 import {
   comboChar,
   comboEmpty,
@@ -16,25 +15,25 @@ describe("#11: phraseScore", () => {
     it("for an empty phrase", () => {
       const { phrase, comboActive, expectedScore } = noComboEmpty;
       const result = phraseScore(phrase, comboActive);
-      expect(result).to.equal(expectedScore);
+      expect(result).toBe(expectedScore);
     });
 
     it("for a single character phrase", () => {
       const { phrase, comboActive, expectedScore } = noComboChar;
       const result = phraseScore(phrase, comboActive);
-      expect(result).to.equal(expectedScore);
+      expect(result).toBe(expectedScore);
     });
 
     it("for a phrase without consecutive repeating letters", () => {
       const { phrase, comboActive, expectedScore } = noComboPhraseNoRepeats;
       const result = phraseScore(phrase, comboActive);
-      expect(result).to.equal(expectedScore);
+      expect(result).toBe(expectedScore);
     });
 
     it("for a phrase with consecutive repeating letters", () => {
       const { phrase, comboActive, expectedScore } = noComboPhraseHasRepeats;
       const result = phraseScore(phrase, comboActive);
-      expect(result).to.equal(expectedScore);
+      expect(result).toBe(expectedScore);
     });
   });
 
@@ -42,25 +41,25 @@ describe("#11: phraseScore", () => {
     it("for an empty phrase", () => {
       const { phrase, comboActive, expectedScore } = comboEmpty;
       const result = phraseScore(phrase, comboActive);
-      expect(result).to.equal(expectedScore);
+      expect(result).toBe(expectedScore);
     });
 
     it("for a single character phrase", () => {
       const { phrase, comboActive, expectedScore } = comboChar;
       const result = phraseScore(phrase, comboActive);
-      expect(result).to.equal(expectedScore);
+      expect(result).toBe(expectedScore);
     });
 
     it("for a phrase without consecutive repeating letters", () => {
       const { phrase, comboActive, expectedScore } = comboPhraseNoRepeats;
       const result = phraseScore(phrase, comboActive);
-      expect(result).to.equal(expectedScore);
+      expect(result).toBe(expectedScore);
     });
 
     it("for a phrase with consecutive repeating letters", () => {
       const { phrase, comboActive, expectedScore } = comboPhraseHasRepeats;
       const result = phraseScore(phrase, comboActive);
-      expect(result).to.equal(expectedScore);
+      expect(result).toBe(expectedScore);
     });
   });
 });

--- a/topics/js/lessons/07-Adv-Objects/tests/12-manageProfiles.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/12-manageProfiles.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { manageProfiles } from "../12-manageProfiles.js";
 import {
   initialProfiles,
@@ -16,27 +15,27 @@ import {
 describe("#12: manageProfiles", () => {
   it("should return the same profiles object when updates object is empty", () => {
     const result = manageProfiles(initialProfiles, emptyUpdates);
-    expect(result).to.not.equal(initialProfiles);
+    expect(result).not.toBe(initialProfiles);
   });
 
   it("should not change profiles that are not updated", () => {
     const result = manageProfiles(unchangedProfiles, profileUpdates);
-    expect(result).to.deep.equal(expectedProfiles);
+    expect(result).toEqual(expectedProfiles);
   });
 
   it("should add new profiles that are not in the initial profiles", () => {
     const result = manageProfiles(initialProfiles, newProfilesOnly);
-    expect(result).to.deep.equal(expectedNewProfilesOnly);
+    expect(result).toEqual(expectedNewProfilesOnly);
   });
 
   it("should add new profiles from updates when profiles object is empty", () => {
     const result = manageProfiles(emptyProfiles, profileUpdates);
-    expect(result).to.not.equal(profileUpdates);
-    expect(result).to.deep.equal(profileUpdates);
+    expect(result).not.toBe(profileUpdates);
+    expect(result).toEqual(profileUpdates);
   });
 
   it("should correctly overwrite existing profiles with new complete data", () => {
     const result = manageProfiles(initialProfiles, completeOverwriteProfiles);
-    expect(result).to.deep.equal(expectedCompleteOverwriteProfiles);
+    expect(result).toEqual(expectedCompleteOverwriteProfiles);
   });
 });

--- a/topics/js/lessons/07-Adv-Objects/tests/13-objectFlattener.test.js
+++ b/topics/js/lessons/07-Adv-Objects/tests/13-objectFlattener.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { objectFlattener } from "../13-objectFlattener.js";
 import {
   noObjVal,
@@ -14,22 +13,22 @@ describe("#13: objectFlattener", () => {
   describe("objectFlattener", () => {
     it("returns the same object untouched if there are no nested objects", () => {
       const result = objectFlattener(noObjVal);
-      expect(result).to.deep.equal(noObjVal);
+      expect(result).toEqual(noObjVal);
     });
 
     it("flattens a single-nested object", () => {
       const result = objectFlattener(oneObjVal);
-      expect(result).to.deep.equal(oneObjExpected);
+      expect(result).toEqual(oneObjExpected);
     });
 
     it("flattens multiple nested objects", () => {
       const result = objectFlattener(multiObjVal);
-      expect(result).to.deep.equal(multiObjExpected);
+      expect(result).toEqual(multiObjExpected);
     });
 
     it("flattens nested objects with array values", () => {
       const result = objectFlattener(arrayObjVal);
-      expect(result).to.deep.equal(arrayObjExpected);
+      expect(result).toEqual(arrayObjExpected);
     });
   });
 });

--- a/topics/js/lessons/09-Recursion/tests/01-countToTen.test.js
+++ b/topics/js/lessons/09-Recursion/tests/01-countToTen.test.js
@@ -1,42 +1,52 @@
-import { expect } from "chai";
-import sinon from "sinon";
+import { jest } from "@jest/globals";
 import countToTen from "../01-countToTen.js";
 
 xdescribe("#1: countToTen", () => {
-  const logSpy = sinon.spy(console, "log");
-  const countSpy = sinon.spy(countToTen);
-  const oneRun = countSpy(1);
-  const countSpyCalls = logSpy.getCalls();
+  const runCountToTen = () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const countSpy = jest.fn(countToTen);
+    const oneRun = countSpy(1);
+
+    return {
+      oneRun,
+      countSpyCalls: logSpy.mock.calls,
+    };
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   it("returns undefined", () => {
-    expect(oneRun).to.be.undefined;
+    const { oneRun } = runCountToTen();
+    expect(oneRun).toBeUndefined();
   });
 
   describe("for numbers less than 10", () => {
     it("logs startNum first", () => {
-      const firstLogNum = countSpyCalls[0].args[0];
-      expect(firstLogNum).to.equal(1);
+      const { countSpyCalls } = runCountToTen();
+      const firstLogNum = countSpyCalls[0][0];
+      expect(firstLogNum).toBe(1);
     });
 
     it("logs each number between startNum and 10, inclusive", () => {
+      const { countSpyCalls } = runCountToTen();
+
       if (countSpyCalls.length === 0) {
         expect.fail("No numbers have been logged.");
       } else {
         const twoToTenCalls = countSpyCalls.slice(1);
 
-        twoToTenCalls.forEach(({ args }, index) => {
+        twoToTenCalls.forEach(([currentLogVal], index) => {
           const indexMatchToTotal = index + 2; // 0 becomes 2, etc
-          const currentLogVal = args[0]; // compare to matchedIndex
-          expect(indexMatchToTotal).to.equal(currentLogVal);
+          expect(indexMatchToTotal).toBe(currentLogVal);
         });
       }
     });
 
     it("recursively calls itself the correct number of times", () => {
-      expect(countSpyCalls.length).to.equal(10);
+      const { countSpyCalls } = runCountToTen();
+      expect(countSpyCalls).toHaveLength(10);
     });
   });
-
-  // needed as log
-  logSpy.restore();
 });

--- a/topics/js/lessons/09-Recursion/tests/02-repeatStr.test.js
+++ b/topics/js/lessons/09-Recursion/tests/02-repeatStr.test.js
@@ -1,21 +1,24 @@
-import { expect } from "chai";
-import sinon from "sinon";
+import { jest } from "@jest/globals";
 import { counts, repeated } from "../data/02-repeatStr.data.js";
 import { wrapper } from "../02-repeatStr.js";
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
 describe("#2: repeatStr", () => {
   it("returns a string", () => {
     counts.forEach((count) => {
       const result = wrapper.repeatStr("peko", count);
 
-      expect(result).to.be.a.string;
+      expect(typeof result).toBe("string");
     });
   });
 
   it("returns the input string when count is 0", () => {
     const result = wrapper.repeatStr("peko", 0);
 
-    expect(result).to.be.a("string");
+    expect(typeof result).toBe("string");
   });
 
   it("returns the correct string", () => {
@@ -23,22 +26,22 @@ describe("#2: repeatStr", () => {
       const expected = repeated[count];
       const result = wrapper.repeatStr("peko", count);
 
-      expect(expected).to.equal(result);
+      expect(result).toBe(expected);
     });
   });
 
   it("recursively calls itself the correct number of times", () => {
     counts.forEach((count) => {
-      const repeatSpy = sinon.spy(wrapper, "repeatStr");
+      const repeatSpy = jest.spyOn(wrapper, "repeatStr");
 
       repeatSpy("peko", count);
 
       const expectedCalls = count;
-      const calls = repeatSpy.callCount - 1;
+      const calls = repeatSpy.mock.calls.length - 1;
 
-      expect(expectedCalls).to.equal(calls);
+      expect(calls).toBe(expectedCalls);
 
-      repeatSpy.restore();
+      repeatSpy.mockRestore();
     });
   });
 });

--- a/topics/js/lessons/09-Recursion/tests/03-collatzTraveler.test.js
+++ b/topics/js/lessons/09-Recursion/tests/03-collatzTraveler.test.js
@@ -1,33 +1,33 @@
-import { expect } from "chai";
-import sinon from "sinon";
+import { jest } from "@jest/globals";
 import { testNums, correctCounts } from "../data/03-collatzTraveler.data.js";
 import { wrapper } from "../03-collatzTraveler.js";
 
 xdescribe("#3: collatzTripCounter", () => {
-  console.log(typeof wrapper.collatzTripCounter);
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   it("returns a number", () => {
     testNums.forEach((num) => {
-      expect(wrapper.collatzTripCounter(num)).to.be.a("number");
+      expect(typeof wrapper.collatzTripCounter(num)).toBe("number");
     });
   });
 
   it("recursively calls itself the correct number of times", () => {
     testNums.forEach((num) => {
-      // spy on console.log
-      const collatzSpy = sinon.spy(wrapper, "collatzTripCounter");
+      const collatzSpy = jest.spyOn(wrapper, "collatzTripCounter");
 
       // call collatz using num
       collatzSpy(num);
 
       // subtract the spy call from the total callCount (off by one error)
-      const calls = collatzSpy.callCount - 1;
+      const calls = collatzSpy.mock.calls.length - 1;
       const expectedTripLength = correctCounts[num];
 
-      expect(expectedTripLength).to.equal(calls);
+      expect(calls).toBe(expectedTripLength);
 
       // reset log spy for next loop
-      collatzSpy.restore();
+      collatzSpy.mockRestore();
     });
   });
 });

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -16,7 +16,7 @@
     "test:07": "npm run test:jest -- lessons/07-Adv-Objects/tests",
     "test:08": "mocha './lessons/08-Async-Await-APIs/tests/**.js'",
     "server:08": "mocha './lessons/08-Async-Await-APIs/server/tests/**.js'",
-    "test:09": "mocha './lessons/09-Recursion/tests/**.js'",
+    "test:09": "npm run test:jest -- lessons/09-Recursion/tests",
     "test:10": "npm run test:jest -- lessons/10-Classes/tests",
     "test:11": "npm run test:jest -- lessons/11-Data-Structures/tests",
     "test:projects": "npm run test:jest -- projects",

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -13,7 +13,7 @@
     "test:04": "npm run test:jest -- lessons/04-Arrays-and-Loops/tests",
     "test:05": "npm run test:jest -- lessons/05-Callbacks-Iterators/tests",
     "test:06": "npm run test:jest -- lessons/06-Objects/tests",
-    "test:07": "mocha './lessons/07-Adv-Objects/tests/**.js'",
+    "test:07": "npm run test:jest -- lessons/07-Adv-Objects/tests",
     "test:08": "mocha './lessons/08-Async-Await-APIs/tests/**.js'",
     "server:08": "mocha './lessons/08-Async-Await-APIs/server/tests/**.js'",
     "test:09": "mocha './lessons/09-Recursion/tests/**.js'",

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -11,7 +11,7 @@
     "test:02": "npm run test:jest -- lessons/02-Conditionals/tests",
     "test:03": "npm run test:jest -- lessons/03-Methods-and-Functions/tests",
     "test:04": "npm run test:jest -- lessons/04-Arrays-and-Loops/tests",
-    "test:05": "mocha './lessons/05-Callbacks-Iterators/tests/**.js'",
+    "test:05": "npm run test:jest -- lessons/05-Callbacks-Iterators/tests",
     "test:06": "npm run test:jest -- lessons/06-Objects/tests",
     "test:07": "mocha './lessons/07-Adv-Objects/tests/**.js'",
     "test:08": "mocha './lessons/08-Async-Await-APIs/tests/**.js'",


### PR DESCRIPTION
## Description

- Converted lesson 05 callback/iterator tests from Mocha/Chai/Sinon to Jest matchers and Jest mocks.
- Converted lesson 07 advanced object tests to Jest, including `deepClone` global-function guards with `jest.spyOn`.
- Converted lesson 09 recursion tests to Jest while preserving the existing skipped-suite state.
- Updated `test:05`, `test:07`, and `test:09` to run through the shared Jest helper.
- Kept each lesson conversion isolated in its own commit.

## Testing

- `npm run test:05`
- `npm run test:07`
- `npm run test:09`

## Notes

Remaining Chai/Sinon references are limited to lesson 08 async/API/server suites, which are reserved for #177.

## Issues

Closes #176  
Parent #173