### PR TITLE
CODE-178 remove focused tests and add ci guard

### DIFF
--- a/.github/workflows/0X-guide-pr-run-unit-tests.yml
+++ b/.github/workflows/0X-guide-pr-run-unit-tests.yml
@@ -58,7 +58,7 @@ jobs:
           - suite: 08 - Async Await APIs
             command: npm run test:08
           - suite: 08 - Async Await APIs Server
-            command: npm run server:08
+            command: npm run test:08-server
           - suite: 09 - Recursion
             command: npm run test:09
           - suite: 10 - Classes

--- a/.github/workflows/0X-guide-pr-run-unit-tests.yml
+++ b/.github/workflows/0X-guide-pr-run-unit-tests.yml
@@ -15,8 +15,27 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  focused-test-guard:
+    name: Focused test guard
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # Set up Node.js
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      # Guard against accidentally committed focused tests
+      - name: Check for focused tests
+        run: npm run check:focused-tests
+
   test:
     name: ${{ matrix.suite }}
+    needs: focused-test-guard
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:06": "npm --workspace @intro-to-code/js run test:06",
     "test:07": "npm --workspace @intro-to-code/js run test:07",
     "test:08": "npm --workspace @intro-to-code/js run test:08",
+    "test:08-server": "npm --workspace @intro-to-code/js run test:08-server",
     "server:08": "npm --workspace @intro-to-code/js run server:08",
     "test:09": "npm --workspace @intro-to-code/js run test:09",
     "test:10": "npm --workspace @intro-to-code/js run test:10",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:11": "npm --workspace @intro-to-code/js run test:11",
     "test:projects": "npm --workspace @intro-to-code/js run test:projects",
     "test:twitter": "npm --workspace @intro-to-code/js run test:twitter",
+    "check:focused-tests": "node scripts/checkFocusedTests.mjs",
     "test:debug": "mocha './debug/tests/**.test.js'",
     "test:mochawesome": "mocha './**/**.js' --reporter=mochawesome --reporter-options autoOpen=true"
   },

--- a/scripts/checkFocusedTests.mjs
+++ b/scripts/checkFocusedTests.mjs
@@ -1,0 +1,77 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const roots = ["topics/js", "wip-problems"];
+const testFilePattern = /\.(?:c|m)?jsx?$/;
+const focusedTestPattern = /\b(?:describe|it|test)\s*\.\s*only\s*\(/g;
+
+const fileExists = async (filePath) => {
+  try {
+    await readdir(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const walk = async (dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await walk(entryPath)));
+    } else if (testFilePattern.test(entry.name)) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+};
+
+const lineAndColumn = (text, index) => {
+  const beforeMatch = text.slice(0, index);
+  const lines = beforeMatch.split("\n");
+
+  return {
+    line: lines.length,
+    column: lines[lines.length - 1].length + 1,
+  };
+};
+
+const scanFile = async (filePath) => {
+  const text = await readFile(filePath, "utf8");
+  const findings = [];
+
+  for (const match of text.matchAll(focusedTestPattern)) {
+    const location = lineAndColumn(text, match.index);
+    findings.push({ filePath, ...location, match: match[0] });
+  }
+
+  return findings;
+};
+
+const existingRoots = [];
+
+for (const root of roots) {
+  if (await fileExists(root)) {
+    existingRoots.push(root);
+  }
+}
+
+const files = (await Promise.all(existingRoots.map(walk))).flat();
+const findings = (await Promise.all(files.map(scanFile))).flat();
+
+if (findings.length > 0) {
+  console.error("Focused tests are not allowed:");
+
+  for (const { filePath, line, column, match } of findings) {
+    console.error(`- ${filePath}:${line}:${column} ${match}`);
+  }
+
+  process.exit(1);
+}
+
+console.log("No focused tests found.");

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -16,6 +16,7 @@
     "test:07": "npm run test:jest -- lessons/07-Adv-Objects/tests",
     "test:08": "npm run test:jest -- lessons/08-Async-Await-APIs/tests",
     "test:08-server": "npm run test:jest -- lessons/08-Async-Await-APIs/server/tests",
+    "server:08": "npm run test:08-server",
     "test:09": "npm run test:jest -- lessons/09-Recursion/tests",
     "test:10": "npm run test:jest -- lessons/10-Classes/tests",
     "test:11": "npm run test:jest -- lessons/11-Data-Structures/tests",

--- a/wip-problems/debug/05-stringSorter.test.js
+++ b/wip-problems/debug/05-stringSorter.test.js
@@ -18,7 +18,7 @@ import {
 } from "./data/stringSorter.data";
 import { stringSorter } from "../05-stringSorter";
 
-describe.only("#5: stringSorter", () => {
+describe("#5: stringSorter", () => {
   describe("accepts two inputs", () => {
     const sortCBSpy = sinon.spy(moreThanFiveChars);
     const sorterSpy = sinon.spy(stringSorter);

--- a/wip-problems/debug/tests/05-typeCollector.test.js
+++ b/wip-problems/debug/tests/05-typeCollector.test.js
@@ -6,7 +6,7 @@ import {
 } from "../data/typeCollector.data";
 import typeCollector from "../05-typeCollector";
 
-describe.only("#5: typeCollector", () => {
+describe("#5: typeCollector", () => {
   describe("returns an object", () => {
     it("when inputObj has only one value of one type", () => {
       oneOfOneType.forEach((obj) =>


### PR DESCRIPTION
## Description

- Removed focused `.only` usage from WIP debug tests.
- Added `npm run check:focused-tests` to fail when `describe.only`, `it.only`, or `test.only` is present.
- Added a focused-test guard job to the `0X-Guide` PR unit-test workflow.
- Aligned lesson 08 server test aliases:
  - `server:08` remains available for compatibility.
  - `test:08-server` is available as the Jest-style alias.
  - CI now uses `npm run test:08-server`.

## Testing

- `npm run check:focused-tests`
- `npm run test:08`
- `npm run server:08`
- `npm run test:08-server`

## Related

- #3 tracks the longer-term ESLint/Prettier setup that may eventually replace this lightweight focused-test guard with `eslint-plugin-jest`.

## Issues

Closes #178  
Parent #173