### PR TITLE
CODE-179 update GitHub Actions for Jest-backed suites

### DIFF
--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -6,7 +6,7 @@
   "description": "JavaScript lessons and projects for intro-to-code.",
   "scripts": {
     "test": "npm run test:01 && npm run test:02 && npm run test:03 && npm run test:04 && npm run test:05 && npm run test:06 && npm run test:07 && npm run test:08 && npm run test:08-server && npm run test:09 && npm run test:10 && npm run test:11 && npm run test:projects",
-    "test:jest": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config ./jest.config.cjs --runInBand",
+    "test:jest": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config ./jest.config.cjs --runInBand --ci",
     "test:01": "npm run test:jest -- lessons/01-Values-and-Data-Types/01-valuesTypes.test.js",
     "test:02": "npm run test:jest -- lessons/02-Conditionals/tests",
     "test:03": "npm run test:jest -- lessons/03-Methods-and-Functions/tests",


### PR DESCRIPTION
## Description

- Updated the shared JS workspace Jest runner to use `--ci`.
- Keeps the existing per-suite root/workspace script matrix intact.
- Ensures GitHub Actions and local CI-parity runs use Jest’s non-interactive CI behavior while preserving `--runInBand`.

## Testing

- `npm run test:01`
- `npm run check:focused-tests`
- `npm run test:08`
- `npm run test:08-server`

Note: lesson 08 server-backed tests require local server binding, so they need to run outside the restricted sandbox.

## Issues

Closes #179  
Parent #173