### PR TITLE
CODE-181 clean deps and legacy mocha scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "topics/*"
       ],
       "dependencies": {
-        "express": "^4.21.2",
-        "sinon": "^18.0.0"
+        "express": "^4.21.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.22.5",
@@ -21,11 +20,9 @@
         "@babel/preset-env": "^7.22.5",
         "@babel/register": "^7.22.5",
         "@faker-js/faker": "^9.4.0",
-        "chai": "^4.5.0",
         "jest": "^30.4.2",
         "jsdoc-to-markdown": "^7.0.1",
         "jsdocs": "^1.0.0",
-        "mocha": "^8.4.0",
         "nodemon": "^2.0.22",
         "supertest": "^7.0.0"
       }
@@ -2714,6 +2711,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -2723,28 +2721,10 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
-      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
-      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "type-detect": "^4.1.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2888,13 +2868,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.1",
@@ -3259,16 +3232,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ansi-colors": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ansi-escape-sequences": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
@@ -3306,16 +3269,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ansi-styles": {
@@ -3377,16 +3330,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -3649,13 +3592,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -3827,25 +3763,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3884,19 +3801,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -3946,66 +3850,6 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/clone-deep": {
       "version": "4.0.1",
@@ -4353,19 +4197,6 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -4379,19 +4210,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/deep-extend": {
@@ -4462,16 +4280,6 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
-      }
-    },
-    "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dmd": {
@@ -4934,33 +4742,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -5113,16 +4894,6 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -5237,16 +5008,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.x"
-      }
-    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -5273,6 +5034,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5316,16 +5078,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/html-escaper": {
@@ -5556,16 +5308,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
@@ -5597,16 +5339,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-object": {
@@ -6653,19 +6385,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/js2xmlparser": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
@@ -6855,12 +6574,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/just-extend": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
-      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
-      "license": "MIT"
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6918,22 +6631,6 @@
         "uc.micro": "^2.0.0"
       }
     },
-    "node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -6961,29 +6658,6 @@
       "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7237,177 +6911,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/mocha": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
-      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.1",
-        "debug": "4.3.1",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.1.6",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "4.0.0",
-        "log-symbols": "4.0.0",
-        "minimatch": "3.0.4",
-        "ms": "2.1.3",
-        "nanoid": "3.1.20",
-        "serialize-javascript": "5.0.1",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "wide-align": "1.1.3",
-        "workerpool": "6.1.0",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
-      },
-      "engines": {
-        "node": ">= 10.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
-      }
-    },
-    "node_modules/mocha/node_modules/chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.0",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.1"
-      }
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mocha/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mocha/node_modules/readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -7447,37 +6955,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nise": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
-      "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.1.1",
-        "just-extend": "^6.2.0",
-        "path-to-regexp": "^8.3.0"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
-      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -7674,22 +7151,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -7801,16 +7262,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8020,16 +7471,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/range-parser": {
@@ -8344,16 +7785,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/serve-static": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
@@ -8511,45 +7942,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/sinon": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
-      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "11.2.2",
-        "@sinonjs/samsam": "^8.0.0",
-        "diff": "^5.2.0",
-        "nise": "^6.0.0",
-        "supports-color": "^7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/sinon/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/slash": {
@@ -8718,20 +8110,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
@@ -8779,19 +8157,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/strip-ansi-cjs": {
@@ -9082,15 +8447,6 @@
       "license": "0BSD",
       "optional": true
     },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
@@ -9365,16 +8721,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -9405,13 +8751,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/workerpool": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
-      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -9613,99 +8952,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -41,16 +41,13 @@
     "@babel/preset-env": "^7.22.5",
     "@babel/register": "^7.22.5",
     "@faker-js/faker": "^9.4.0",
-    "chai": "^4.5.0",
     "jest": "^30.4.2",
     "jsdoc-to-markdown": "^7.0.1",
     "jsdocs": "^1.0.0",
-    "mocha": "^8.4.0",
     "nodemon": "^2.0.22",
     "supertest": "^7.0.0"
   },
   "dependencies": {
-    "express": "^4.21.2",
-    "sinon": "^18.0.0"
+    "express": "^4.21.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "test:11": "npm --workspace @intro-to-code/js run test:11",
     "test:projects": "npm --workspace @intro-to-code/js run test:projects",
     "test:twitter": "npm --workspace @intro-to-code/js run test:twitter",
-    "check:focused-tests": "node scripts/checkFocusedTests.mjs",
-    "test:debug": "mocha './debug/tests/**.test.js'",
-    "test:mochawesome": "mocha './**/**.js' --reporter=mochawesome --reporter-options autoOpen=true"
+    "check:focused-tests": "node scripts/checkFocusedTests.mjs"
   },
   "repository": {
     "type": "git",

--- a/wip-problems/debug/05-stringSorter.test.js
+++ b/wip-problems/debug/05-stringSorter.test.js
@@ -1,5 +1,4 @@
-import { expect } from "chai";
-import sinon from "sinon";
+import { jest } from "@jest/globals";
 import {
   moreThanFiveChars,
   allLessThanFive,
@@ -20,21 +19,20 @@ import { stringSorter } from "../05-stringSorter";
 
 describe("#5: stringSorter", () => {
   describe("accepts two inputs", () => {
-    const sortCBSpy = sinon.spy(moreThanFiveChars);
-    const sorterSpy = sinon.spy(stringSorter);
+    const sortCBSpy = jest.fn(moreThanFiveChars);
+    const sorterSpy = jest.fn(stringSorter);
     sorterSpy(allLessThanFive, sortCBSpy);
 
     it("a string array", () => {
-      const hasStringArr = sorterSpy.calledWith(allLessThanFive);
-      expect(hasStringArr).to.be.true;
+      expect(sorterSpy).toHaveBeenCalledWith(allLessThanFive, sortCBSpy);
     });
 
     it("a callback function", () => {
-      expect(true).to.be.false;
+      expect(true).toBe(false);
     });
   });
 
   it("returns an object", () => {
-    expect(true).to.be.false;
+    expect(true).toBe(false);
   });
 });

--- a/wip-problems/debug/tests/03-coolNumbersClub.test.js
+++ b/wip-problems/debug/tests/03-coolNumbersClub.test.js
@@ -1,5 +1,3 @@
-import { expect } from "chai";
-import sinon from "sinon";
 import { allCool, allUncool, mixedCool } from "../data/coolNumbersClub.data";
 import { coolNumbersClub } from "../03-coolNumbersClub";
 
@@ -8,19 +6,19 @@ describe("#3: coolNumbersClub", () => {
     it("when all the numbers are cool", () => {
       expect(
         coolNumbersClub(allCool, isNumberCool, coolSquaredNumbers)
-      ).to.be.an("array");
+      ).toEqual(expect.any(Array));
     });
 
     it("when all the numbers are uncool", () => {
       expect(
         coolNumbersClub(allUncool, isNumberCool, coolSquaredNumbers)
-      ).to.be.an("array");
+      ).toEqual(expect.any(Array));
     });
 
     it("when there's a mix of cool and uncool numbers", () => {
       expect(
         coolNumbersClub(mixedCool, isNumberCool, coolSquaredNumbers)
-      ).to.be.an("array");
+      ).toEqual(expect.any(Array));
     });
   });
 
@@ -28,6 +26,6 @@ describe("#3: coolNumbersClub", () => {
     console.log(allUncool.filter(isNumberCool));
     expect(
       coolNumbersClub(allUncool, isNumberCool, coolSquaredNumbers)
-    ).to.deep.equal([]);
+    ).toEqual([]);
   });
 });

--- a/wip-problems/debug/tests/04-atbashEncoder.test.js
+++ b/wip-problems/debug/tests/04-atbashEncoder.test.js
@@ -1,23 +1,22 @@
-import { expect } from "chai";
 import { characters } from "../data/atbashEncoder.data";
 import atbashEncoder from "../04-atbashEncoder";
 
 describe("#4: atbashEncoder", () => {
   const result = atbashEncoder();
   it("returns an object", () => {
-    expect(result).to.be.an("object");
+    expect(result).toEqual(expect.any(Object));
   });
 
   it("that has 26 keys for the 26 letters of the alphabet", () => {
     const keyCount = Object.keys(result).length;
-    expect(keyCount).to.equal(26);
+    expect(keyCount).toBe(26);
   });
 
   it("has the correct encoded letter value assigned to each key", () => {
     characters.forEach((char, index, arr) => {
       const encodedChar = arr[25 - index];
       const currTestValue = result[char];
-      expect(currTestValue).to.equal(encodedChar);
+      expect(currTestValue).toBe(encodedChar);
     });
   });
 });

--- a/wip-problems/debug/tests/05-typeCollector.test.js
+++ b/wip-problems/debug/tests/05-typeCollector.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import {
   oneOfOneType,
   manyOfOneType,
@@ -10,19 +9,19 @@ describe("#5: typeCollector", () => {
   describe("returns an object", () => {
     it("when inputObj has only one value of one type", () => {
       oneOfOneType.forEach((obj) =>
-        expect(typeCollector(obj)).to.be.an("object")
+        expect(typeCollector(obj)).toEqual(expect.any(Object))
       );
     });
 
     it("when inputObj has many values of one type", () => {
       manyOfOneType.forEach((obj) =>
-        expect(typeCollector(obj)).to.be.an("object")
+        expect(typeCollector(obj)).toEqual(expect.any(Object))
       );
     });
 
     it("when inputObj has many values of many types", () => {
       manyOfManyTypes.forEach((obj) =>
-        expect(typeCollector(obj)).to.be.an("object")
+        expect(typeCollector(obj)).toEqual(expect.any(Object))
       );
     });
   });
@@ -34,7 +33,7 @@ describe("#5: typeCollector", () => {
           const testObjKeysCount = Object.keys(obj).length;
           const resultKeysCount = Object.keys(obj).length;
 
-          expect(resultKeysCount).to.equal(testObjKeysCount);
+          expect(resultKeysCount).toBe(testObjKeysCount);
         });
       });
     });
@@ -44,7 +43,7 @@ describe("#5: typeCollector", () => {
         it(`${JSON.stringify(obj)}`, () => {
           const testObjKeysCount = Object.keys(obj).length;
           const resultKeysCount = Object.keys(obj).length;
-          expect(resultKeysCount).to.equal(testObjKeysCount);
+          expect(resultKeysCount).toBe(testObjKeysCount);
         });
       });
     });
@@ -54,7 +53,7 @@ describe("#5: typeCollector", () => {
         it(`${JSON.stringify(obj)}`, () => {
           const testObjKeysCount = Object.keys(obj).length;
           const resultKeysCount = Object.keys(obj).length;
-          expect(resultKeysCount).to.equal(testObjKeysCount);
+          expect(resultKeysCount).toBe(testObjKeysCount);
         });
       });
     });
@@ -79,7 +78,7 @@ describe("#5: typeCollector", () => {
         (key, index) => key === expectedKeys[index]
       );
 
-      expect(keyTester).to.be.true;
+      expect(keyTester).toBe(true);
     });
   });
 
@@ -96,7 +95,7 @@ describe("#5: typeCollector", () => {
   //   const resultKeys = Object.keys(typeCollector(obj));
   //   const typesCheck = types.every((type) => resultKeys.indexOf(type) !== -1);
 
-  //   expect(resultKeys).to.equal(typesCheck);
+  //   expect(resultKeys).toBe(typesCheck);
   // });
   // manyOfManyTypes.forEach((obj) => {
   //   const types = Object.values(obj).map((value) => {
@@ -108,6 +107,6 @@ describe("#5: typeCollector", () => {
   //   const resultKeys = Object.keys(typeCollector(obj));
   //   const typesCheck = types.every((type) => resultKeys.indexOf(type) !== -1);
 
-  //   expect(resultKeys).to.equal(typesCheck);
+  //   expect(resultKeys).toBe(typesCheck);
   // });
 });

--- a/wip-problems/debug/tests/06-caesarCrafter.test.js
+++ b/wip-problems/debug/tests/06-caesarCrafter.test.js
@@ -10,59 +10,58 @@ import {
   byNeg52,
   byNeg125,
 } from "./06-caesarCrafter.test.data";
-import { expect } from "chai";
 
 describe("#6: caesarCipher", () => {
   describe("returns the base cipher", () => {
     it("when the shiftAmount is 0", () => {
       const result = caesarCipher(0);
-      expect(result).to.deep.equal(baseCaesar);
+      expect(result).toEqual(baseCaesar);
     });
   });
 
   describe("returns the correct cipher when shiftAmount is positive", () => {
     it("shiftAmount = 2", () => {
       const pos2 = caesarCipher(2);
-      expect(pos2).to.deep.equal(byPos2);
+      expect(pos2).toEqual(byPos2);
     });
 
     it("shiftAmount = 13", () => {
       const pos13 = caesarCipher(13);
-      expect(pos13).to.deep.equal(byPos13);
+      expect(pos13).toEqual(byPos13);
     });
   });
 
   describe("returns the correct cipher when shiftAmount is negative", () => {
     it("shiftAmount = -2", () => {
       const neg2 = caesarCipher(-2);
-      expect(neg2).to.deep.equal(byNeg2);
+      expect(neg2).toEqual(byNeg2);
     });
 
     it("shiftAmount = -13", () => {
       const neg13 = caesarCipher(-13);
-      expect(neg13).to.deep.equal(byNeg13);
+      expect(neg13).toEqual(byNeg13);
     });
   });
 
   describe("BONUS: shiftAmount > 26 OR shiftAmount < -26", () => {
     it("shiftAmount = 52", () => {
       const pos52 = caesarCipher(52);
-      expect(pos52).to.deep.equal(byPos52);
+      expect(pos52).toEqual(byPos52);
     });
 
     it("shiftAmount = 125", () => {
       const pos125 = caesarCipher(125);
-      expect(pos125).to.deep.equal(byPos125);
+      expect(pos125).toEqual(byPos125);
     });
 
     it("shiftAmount = -52", () => {
       const neg52 = caesarCipher(-52);
-      expect(neg52).to.deep.equal(byNeg52);
+      expect(neg52).toEqual(byNeg52);
     });
 
     it("shiftAmount = -125", () => {
       const neg125 = caesarCipher(-125);
-      expect(neg125).to.deep.equal(byNeg125);
+      expect(neg125).toEqual(byNeg125);
     });
   });
 });

--- a/wip-problems/debug/tests/06-uniquePropCollector.test.js
+++ b/wip-problems/debug/tests/06-uniquePropCollector.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { uniquePropCollector } from "../06-uniquePropCollector";
 import {
   hasAllUnique,
@@ -22,56 +21,56 @@ import {
 describe("uniquePropCollector", () => {
   it("should handle an empty array", () => {
     const result = uniquePropCollector([]);
-    expect(result).to.deep.equal({});
+    expect(result).toEqual({});
   });
 
   describe("array with a single object", () => {
     it("single-key value pair", () => {
       const result = uniquePropCollector(oneObjSingleKV);
-      expect(result).to.deep.equal(oneObjSingleKVExpected);
+      expect(result).toEqual(oneObjSingleKVExpected);
     });
 
     it("multiple key-value pairs", () => {
       const result = uniquePropCollector(oneObjSingleKV);
-      expect(result).to.deep.equal(oneObjSingleKVExpected);
+      expect(result).toEqual(oneObjSingleKVExpected);
     });
   });
 
   describe("array with multiple objects", () => {
     it("multiple identical objects", () => {
       const result = uniquePropCollector(multipleIdentical);
-      expect(result).to.deep.equal(multipleIdenticalExpected);
+      expect(result).toEqual(multipleIdenticalExpected);
     });
 
     it("should handle properties with undefined values", () => {
       const result = uniquePropCollector(hasUndef);
-      expect(result).to.deep.equal(hasUndefExpected);
+      expect(result).toEqual(hasUndefExpected);
     });
 
     it("should handle properties with null values", () => {
       const result = uniquePropCollector(hasNull);
-      expect(result).to.deep.equal(hasNullExpected);
+      expect(result).toEqual(hasNullExpected);
     });
 
     it("should collect unique values for each property", () => {
       const result = uniquePropCollector(hasAllUnique);
-      expect(result).to.deep.equal(hasAllUniqueExpected);
+      expect(result).toEqual(hasAllUniqueExpected);
     });
 
     it("should handle objects with overlapping and unique properties", () => {
       const result = uniquePropCollector(hasOverlapping);
-      expect(result).to.deep.equal(hasOverlappingExpected);
+      expect(result).toEqual(hasOverlappingExpected);
     });
 
     it("should handle different data types", () => {
       const result = uniquePropCollector(hasDiffDataTypes);
-      expect(result).to.deep.equal(hasDiffDataTypesExpected);
+      expect(result).toEqual(hasDiffDataTypesExpected);
     });
 
     it("should not process nested properties", () => {
       const result = uniquePropCollector(hasNested);
       console.log(result);
-      expect(result).to.deep.equal(hasNestedExpected);
+      expect(result).toEqual(hasNestedExpected);
     });
 
     it("should handle objects with large number of properties", () => {
@@ -84,7 +83,7 @@ describe("uniquePropCollector", () => {
       for (let i = 0; i < 1000; i++) {
         expected[`prop${i}`] = new Set([i]);
       }
-      expect(result).to.deep.equal(expected);
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/wip-problems/debug/tests/dynamicPropAccessor.test.js
+++ b/wip-problems/debug/tests/dynamicPropAccessor.test.js
@@ -1,4 +1,3 @@
-import { expect } from "chai";
 import { DynamicPropAccessor } from "../dynamicPropAccessor";
 import {
   baseData,
@@ -10,18 +9,18 @@ import {
 describe("#XX: DynamicPropAccessor", () => {
   it("base condition met", () => {
     const result = DynamicPropAccessor(baseData);
-    expect(result).to.deep.equal(baseExpected);
+    expect(result).toEqual(baseExpected);
   });
 
   describe("nested set of conditions", () => {
     it("nested test condition", () => {
       const result = DynamicPropAccessor(baseData);
-      expect(result).to.deep.equal(baseExpected);
+      expect(result).toEqual(baseExpected);
     });
 
     it("other nested test condition", () => {
       const result = DynamicPropAccessor(caseOne);
-      expect(result).to.deep.equal(caseOneExpected);
+      expect(result).toEqual(caseOneExpected);
     });
   });
 });

--- a/wip-problems/groceryRegister.js
+++ b/wip-problems/groceryRegister.js
@@ -183,13 +183,13 @@ describe("#: groceryRegister", () => {
   const baseGroceryLists = Array.of(orderOne, orderTwo);
   it("returns a number representing the total price", () => {
     baseGroceryLists.map((list) => {
-      expect(groceryRegister(list)).to.be.a("number");
+      expect(groceryRegister(list)).toEqual(expect.any(Number));
     });
   });
 
   it("returns", () => {
-    expect(groceryRegister(orderOne)).to.equal(11.49);
-    expect(groceryRegister(orderTwo)).to.equal(39.45);
+    expect(groceryRegister(orderOne)).toBe(11.49);
+    expect(groceryRegister(orderTwo)).toBe(39.45);
   });
 
   describe("BONUS: can handle orders where items are out of stock", () => {

--- a/wip-problems/myConcat.js
+++ b/wip-problems/myConcat.js
@@ -56,12 +56,12 @@ myConcat(firstArray, secondArray);
 // console.log(firstArray)
 // console.log(secondArray)
 
-import { expect } from "chai";
-
-describe("#: myConcat", () => {
+describe.skip("#: myConcat", () => {
   const arr1 = [1, 2, 3];
   const arr2 = [4, 5, 6];
   it("doesn't modify either input array", () => {
-    expect(myConcat.)
+    expect(myConcat(arr1, arr2)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(arr1).toEqual([1, 2, 3]);
+    expect(arr2).toEqual([4, 5, 6]);
   });
 });

--- a/wip-problems/tests/wordFrequencyAnalyzer.test.js
+++ b/wip-problems/tests/wordFrequencyAnalyzer.test.js
@@ -1,11 +1,10 @@
-import { expect } from "chai";
 import { wordFrequencyAnalyzer } from "../wordFrequencyAnalyzer";
 
 describe("wordFrequencyAnalyzer", () => {
   it("should count word frequencies correctly", () => {
     const text = "Hello, hello! How are you? Are you there?";
     const result = wordFrequencyAnalyzer(text);
-    expect(result).to.deep.equal(
+    expect(result).toEqual(
       new Map([
         ["hello", 2],
         ["how", 1],
@@ -19,18 +18,18 @@ describe("wordFrequencyAnalyzer", () => {
   it("should handle an empty string", () => {
     const text = "";
     const result = wordFrequencyAnalyzer(text);
-    expect(result).to.deep.equal(new Map());
+    expect(result).toEqual(new Map());
   });
 
   it("should ignore punctuation and be case insensitive", () => {
     const text = "Hi! Hi? HI. hi, hi";
     const result = wordFrequencyAnalyzer(text);
-    expect(result).to.deep.equal(new Map([["hi", 5]]));
+    expect(result).toEqual(new Map([["hi", 5]]));
   });
 
   it("should handle a text with one word", () => {
     const text = "test";
     const result = wordFrequencyAnalyzer(text);
-    expect(result).to.deep.equal(new Map([["test", 1]]));
+    expect(result).toEqual(new Map([["test", 1]]));
   });
 });


### PR DESCRIPTION
## Description

- Remove legacy root Mocha script aliases: `test:debug` and `test:mochawesome`
- Convert remaining WIP/debug Chai/Sinon assertions to Jest syntax so the repo no longer needs those packages
- Remove `chai`, `mocha`, and `sinon` from `package.json` and `package-lock.json`
- Keep `supertest` for the lesson 08 Express route tests

## Testing

- `npm ci`
- `npm ls mocha chai sinon --depth=0`
  - confirms the packages are gone by returning `(empty)`
- `npm run check:focused-tests`
- `npm run test:js`

### Issues

Closes #181  
#173