### PR TITLE
CODE-182 verify guide and student branch testing behavior

### DIFF
--- a/.github/workflows/main-student-clean.yml
+++ b/.github/workflows/main-student-clean.yml
@@ -1,6 +1,11 @@
 name: Student Main Clean Check
 
 on:
+  # Guard direct upstream main updates, if any, after a release merge.
+  push:
+    branches:
+      - "main"
+  # Guard PRs that would update upstream main from dev or another release branch.
   pull_request:
     branches:
       - "main"
@@ -8,6 +13,8 @@ on:
 
 jobs:
   student-clean:
+    # Students may fork this repo and use their own main branch for notes or
+    # class material. Only enforce the student-clean tree on the upstream repo.
     if: github.repository == 'chrismejia/intro-to-code-js'
     runs-on: ubuntu-latest
     steps:
@@ -21,5 +28,7 @@ jobs:
 
       - name: Check student-clean tree
         env:
+          # The script also has the upstream-only guard so fork-owned workflow
+          # runs skip cleanly if this workflow is copied or triggered there.
           STUDENT_CLEAN_UPSTREAM_ONLY: "true"
         run: npm run check:student-clean

--- a/.github/workflows/main-student-clean.yml
+++ b/.github/workflows/main-student-clean.yml
@@ -1,0 +1,25 @@
+name: Student Main Clean Check
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    types: [opened, synchronize, reopened]
+
+jobs:
+  student-clean:
+    if: github.repository == 'chrismejia/intro-to-code-js'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Check student-clean tree
+        env:
+          STUDENT_CLEAN_UPSTREAM_ONLY: "true"
+        run: npm run check:student-clean

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -7,6 +7,7 @@ This folder holds maintainer-facing notes for repository organization and curric
 - [Git basics](git-basics.md): beginner-friendly Git commands and expected status messages.
 - [Branching and PR workflow](pr-workflow.md): issue branches, pull requests, and target branch expectations.
 - [Repository layout](repository-layout.md): topic workspace structure, script ownership, branch-audience notes, and future `AGENTS.md` guidance.
+- [Testing branch behavior](testing-branch-behavior.md): Jest expectations for guide, release staging, upstream `main`, and student forks.
 - `chatgpt/`: prompt/support material for generating or revising lesson JSDoc.
 
 Student-facing setup and test instructions belong in the root [README.md](../README.md). Keep this folder focused on how the repository is organized and maintained.
@@ -25,7 +26,7 @@ Generated WIP problem tests come from `scripts/generateFiles.sh` and should use 
 
 The focused-test guard lives at `scripts/checkFocusedTests.mjs` and is exposed as `npm run check:focused-tests`. It should fail if `describe.only`, `it.only`, or `test.only` appears in active curriculum or WIP paths.
 
-For branch expectations, `0X-Guide` should run active guide tests against answer-bearing files. Student-facing `main` should not ship filled answers, and its tests should be pending, skipped, or otherwise safe for starter-code files. Use `dev` as the staging branch for preparing that student-clean state.
+For branch expectations, `0X-Guide` should run active guide tests against answer-bearing files. Student-facing `main` should not ship filled answers, and its tests should be pending, skipped, or otherwise safe for starter-code files. Use `dev` as the staging branch for preparing that student-clean state. See [Testing branch behavior](testing-branch-behavior.md) for the release checklist and fork-specific notes.
 
 ## Future AGENTS.md Note
 

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -26,6 +26,8 @@ Generated WIP problem tests come from `scripts/generateFiles.sh` and should use 
 
 The focused-test guard lives at `scripts/checkFocusedTests.mjs` and is exposed as `npm run check:focused-tests`. It should fail if `describe.only`, `it.only`, or `test.only` appears in active curriculum or WIP paths.
 
+The student-clean guard lives at `scripts/checkStudentClean.mjs` and is exposed as `npm run check:student-clean`. It should fail if upstream `main` would include top-level instructor-only paths such as `docs/`, `teaching-notes/`, or `wip-problems`.
+
 For branch expectations, `0X-Guide` should run active guide tests against answer-bearing files. Student-facing `main` should not ship filled answers, and its tests should be pending, skipped, or otherwise safe for starter-code files. Use `dev` as the staging branch for preparing that student-clean state. See [Testing branch behavior](testing-branch-behavior.md) for the release checklist and fork-specific notes.
 
 ## Future AGENTS.md Note

--- a/docs/pr-workflow.md
+++ b/docs/pr-workflow.md
@@ -129,3 +129,9 @@ Use the target branch that matches the audience:
 - Student-facing final release targets `main`.
 
 Do not open answer-rich instructor work directly into `main`.
+
+Before opening a `dev` to `main` release PR, read
+[Testing branch behavior](testing-branch-behavior.md). The upstream
+`chrismejia/intro-to-code-js` `main` tree should be student-clean, while
+student forks are allowed to keep personal notes or class material on their own
+branches.

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -97,6 +97,9 @@ Do not merge answer-rich instructor work directly into `main`.
 
 Testing should follow the same audience split. Pull requests targeting `0X-Guide` should run active guide tests and expect them to pass against answer-bearing files. Student-facing `main` should keep tests pending, skipped, or otherwise safe for starter-code files.
 
+More detailed branch-specific testing and release cleanup expectations live in
+[Testing branch behavior](testing-branch-behavior.md).
+
 ## Future AGENTS.md Guidance
 
 When `AGENTS.md` is committed later, keep it short and point to this file for details. A useful starter note would be:

--- a/docs/testing-branch-behavior.md
+++ b/docs/testing-branch-behavior.md
@@ -1,0 +1,78 @@
+# Testing Branch Behavior
+
+Use this guide when changing tests, release flow, or branch-specific CI.
+
+## `0X-Guide` And Feature Branches
+
+`0X-Guide` is the instructor source of truth. It should keep answer-bearing
+lesson files and run real Jest-backed tests against those answers.
+
+For guide work, run the focused-test guard plus the affected suite:
+
+```shell
+npm run check:focused-tests
+npm run test:09
+```
+
+For migration or shared test-runner changes, run the full JS suite:
+
+```shell
+npm run test:js
+```
+
+Pull requests targeting `0X-Guide` should expect active tests to pass. Do not
+make guide tests pending just to hide missing or broken answers.
+
+## `dev` Release Staging
+
+Use `dev` to prepare the student-facing tree before it reaches `main`.
+
+Before opening a `dev` to `main` pull request:
+
+1. Remove filled answers from lesson and project starter files.
+2. Remove instructor-only material from the current tree, including
+   `docs/`, `base/`, `teaching-notes/`, `wip-problems/`, and `AGENTS.md`.
+3. Convert guide-only tests so starter code is safe. Prefer Jest APIs such as
+   `describe.skip`, `it.skip`, or `test.skip`, or use a starter-safe harness.
+4. Keep `npm run check:focused-tests` passing.
+5. Run the student-safe test commands that should remain available on `main`.
+
+Skipped or pending student tests should use Jest-compatible APIs. Do not
+reintroduce Mocha-only pending behavior during release cleanup.
+
+## Upstream `main`
+
+`chrismejia/intro-to-code-js` `main` is the student-facing release branch.
+The current tree should stay student-clean:
+
+- no filled answers in lesson or project starter files
+- no instructor-only folders such as `docs/`, `base/`, `teaching-notes/`, or
+  `wip-problems/`
+- no maintainer-only agent instructions such as `AGENTS.md`
+- no guide-only tests that fail against blank starter files
+
+When checking the upstream release branch from a local checkout, refresh refs
+first, then inspect the remote tree:
+
+```shell
+git fetch origin main
+git ls-tree -r --name-only origin/main | rg '^(docs|base|teaching-notes|wip-problems)/|AGENTS\.md$'
+```
+
+No output from that command means those top-level instructor-only paths are not
+present on upstream `main`.
+
+## Student Forks
+
+Students may fork this repository and use their own `main` branch for notes,
+scratch work, and copies of teaching notes shared during class.
+
+Any automated student-clean check should only enforce the upstream repository,
+for example:
+
+```yaml
+if: github.repository == 'chrismejia/intro-to-code-js'
+```
+
+Do not block fork-owned `main` pushes just because a student's fork contains a
+`notes/` folder or class material they were given for their own work.

--- a/docs/testing-branch-behavior.md
+++ b/docs/testing-branch-behavior.md
@@ -56,11 +56,11 @@ first, then inspect the remote tree:
 
 ```shell
 git fetch origin main
-git ls-tree -r --name-only origin/main | rg '^(docs|base|teaching-notes|wip-problems)/|AGENTS\.md$'
+npm run check:student-clean -- --ref origin/main
 ```
 
-No output from that command means those top-level instructor-only paths are not
-present on upstream `main`.
+`Student-clean check passed.` means those top-level instructor-only paths are
+not present on upstream `main`.
 
 ## Student Forks
 
@@ -73,6 +73,9 @@ for example:
 ```yaml
 if: github.repository == 'chrismejia/intro-to-code-js'
 ```
+
+The `Student Main Clean Check` workflow uses that condition so fork-owned repos
+can keep local class material without fighting upstream release rules.
 
 Do not block fork-owned `main` pushes just because a student's fork contains a
 `notes/` folder or class material they were given for their own work.

--- a/docs/testing-branch-behavior.md
+++ b/docs/testing-branch-behavior.md
@@ -74,8 +74,9 @@ for example:
 if: github.repository == 'chrismejia/intro-to-code-js'
 ```
 
-The `Student Main Clean Check` workflow uses that condition so fork-owned repos
-can keep local class material without fighting upstream release rules.
+The `Student Main Clean Check` workflow uses that condition for pull requests
+and pushes to `main`, so fork-owned repos can keep local class material without
+fighting upstream release rules.
 
 Do not block fork-owned `main` pushes just because a student's fork contains a
 `notes/` folder or class material they were given for their own work.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:11": "npm --workspace @intro-to-code/js run test:11",
     "test:projects": "npm --workspace @intro-to-code/js run test:projects",
     "test:twitter": "npm --workspace @intro-to-code/js run test:twitter",
-    "check:focused-tests": "node scripts/checkFocusedTests.mjs"
+    "check:focused-tests": "node scripts/checkFocusedTests.mjs",
+    "check:student-clean": "node scripts/checkStudentClean.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/checkStudentClean.mjs
+++ b/scripts/checkStudentClean.mjs
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+const upstreamRepository = "chrismejia/intro-to-code-js";
+const forbiddenTopLevelPaths = [
+  "AGENTS.md",
+  "base",
+  "docs",
+  "teaching-notes",
+  "wip-problems",
+];
+
+const args = process.argv.slice(2);
+const ref = getArgValue("--ref");
+
+if (args.includes("--help")) {
+  printHelp();
+  process.exit(0);
+}
+
+if (shouldSkipForFork()) {
+  console.log(
+    `Skipping student-clean check for fork repository ${process.env.GITHUB_REPOSITORY}.`
+  );
+  process.exit(0);
+}
+
+const paths = ref ? getGitTreePaths(ref) : getWorkingTreePaths();
+const failures = forbiddenTopLevelPaths.filter((forbiddenPath) =>
+  hasPath(paths, forbiddenPath)
+);
+
+if (failures.length > 0) {
+  console.error("Student-clean check failed.");
+  console.error(
+    "The upstream main tree must not include instructor-only paths:"
+  );
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+console.log("Student-clean check passed.");
+
+function getArgValue(name) {
+  const index = args.indexOf(name);
+
+  if (index === -1) {
+    return null;
+  }
+
+  const value = args[index + 1];
+
+  if (!value || value.startsWith("--")) {
+    console.error(`${name} requires a value.`);
+    process.exit(1);
+  }
+
+  return value;
+}
+
+function shouldSkipForFork() {
+  return (
+    process.env.STUDENT_CLEAN_UPSTREAM_ONLY === "true" &&
+    process.env.GITHUB_REPOSITORY &&
+    process.env.GITHUB_REPOSITORY !== upstreamRepository
+  );
+}
+
+function getWorkingTreePaths() {
+  return new Set(readdirSync(process.cwd()));
+}
+
+function getGitTreePaths(treeRef) {
+  try {
+    const output = execFileSync(
+      "git",
+      ["ls-tree", "-r", "--name-only", treeRef],
+      {
+        encoding: "utf8",
+      }
+    );
+
+    return new Set(output.split("\n").filter(Boolean));
+  } catch (error) {
+    console.error(`Unable to inspect git tree ${treeRef}.`);
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+function hasPath(paths, forbiddenPath) {
+  if (paths.has(forbiddenPath)) {
+    return true;
+  }
+
+  const prefix = `${forbiddenPath}${path.posix.sep}`;
+  return [...paths].some((repoPath) => repoPath.startsWith(prefix));
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/checkStudentClean.mjs [--ref <git-ref>]
+
+Checks for top-level instructor-only paths that should not ship on upstream
+main. Set STUDENT_CLEAN_UPSTREAM_ONLY=true in CI to skip fork-owned repos.`);
+}

--- a/scripts/checkStudentClean.mjs
+++ b/scripts/checkStudentClean.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import path from "node:path";
 
 const upstreamRepository = "chrismejia/intro-to-code-js";
@@ -11,38 +11,7 @@ const forbiddenTopLevelPaths = [
   "wip-problems",
 ];
 
-const args = process.argv.slice(2);
-const ref = getArgValue("--ref");
-
-if (args.includes("--help")) {
-  printHelp();
-  process.exit(0);
-}
-
-if (shouldSkipForFork()) {
-  console.log(
-    `Skipping student-clean check for fork repository ${process.env.GITHUB_REPOSITORY}.`
-  );
-  process.exit(0);
-}
-
-const paths = ref ? getGitTreePaths(ref) : getWorkingTreePaths();
-const failures = forbiddenTopLevelPaths.filter((forbiddenPath) =>
-  hasPath(paths, forbiddenPath)
-);
-
-if (failures.length > 0) {
-  console.error("Student-clean check failed.");
-  console.error(
-    "The upstream main tree must not include instructor-only paths:"
-  );
-  failures.forEach((failure) => console.error(`- ${failure}`));
-  process.exit(1);
-}
-
-console.log("Student-clean check passed.");
-
-function getArgValue(name) {
+function getArgValue(args, name) {
   const index = args.indexOf(name);
 
   if (index === -1) {
@@ -78,7 +47,7 @@ function getGitTreePaths(treeRef) {
       ["ls-tree", "-r", "--name-only", treeRef],
       {
         encoding: "utf8",
-      }
+      },
     );
 
     return new Set(output.split("\n").filter(Boolean));
@@ -104,3 +73,41 @@ function printHelp() {
 Checks for top-level instructor-only paths that should not ship on upstream
 main. Set STUDENT_CLEAN_UPSTREAM_ONLY=true in CI to skip fork-owned repos.`);
 }
+
+function main() {
+  console.log("Running student-clean check...");
+
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help")) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const ref = getArgValue(args, "--ref");
+
+  if (shouldSkipForFork()) {
+    console.log(
+      `Skipping student-clean check for fork repository ${process.env.GITHUB_REPOSITORY}.`,
+    );
+    process.exit(0);
+  }
+
+  const paths = ref ? getGitTreePaths(ref) : getWorkingTreePaths();
+  const failures = forbiddenTopLevelPaths.filter((forbiddenPath) =>
+    hasPath(paths, forbiddenPath),
+  );
+
+  if (failures.length > 0) {
+    console.error("Student-clean check failed.");
+    console.error(
+      "The upstream main tree must not include instructor-only paths:",
+    );
+    failures.forEach((failure) => console.error(`- ${failure}`));
+    process.exit(1);
+  }
+
+  console.log("Student-clean check passed.");
+}
+
+main();

--- a/topics/js/lessons/09-Recursion/tests/01-countToTen.test.js
+++ b/topics/js/lessons/09-Recursion/tests/01-countToTen.test.js
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals";
 import countToTen from "../01-countToTen.js";
 
-xdescribe("#1: countToTen", () => {
+describe.skip("#1: countToTen", () => {
   const runCountToTen = () => {
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     const countSpy = jest.fn(countToTen);

--- a/topics/js/lessons/09-Recursion/tests/03-collatzTraveler.test.js
+++ b/topics/js/lessons/09-Recursion/tests/03-collatzTraveler.test.js
@@ -2,7 +2,7 @@ import { jest } from "@jest/globals";
 import { testNums, correctCounts } from "../data/03-collatzTraveler.data.js";
 import { wrapper } from "../03-collatzTraveler.js";
 
-xdescribe("#3: collatzTripCounter", () => {
+describe.skip("#3: collatzTripCounter", () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });


### PR DESCRIPTION
## Summary

- Add `scripts/checkStudentClean.mjs` and `npm run check:student-clean` to guard upstream `main` against top-level instructor-only paths.
- Add a `Student Main Clean Check` workflow for upstream `main` pushes and PRs, while allowing student forks to keep their own notes/class material.
- Document branch-specific testing behavior for `0X-Guide`, `dev`, `main`, and student forks.
- Replace lesson 09 `xdescribe` usage with Jest-compatible `describe.skip`.

## Testing

- `npm run check:focused-tests`
- `npm run test:09`
- `npm run test:js`

## Issues

Parent #173 
Closes #182 

### Notes

- This branch is guide-side work and should not be merged directly into `main`.
- `npm run check:student-clean -- --ref origin/main` currently fails because upstream `main` still contains `teaching-notes`; that looks like release cleanup follow-up rather than a CODE-182 branch failure.