### PR TITLE
CODE-187 add deterministic Jest test sequencer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# Repository Instructions
+
+## Project Shape
+
+For supporting detail, see [Maintainer Guide](docs/maintainer-guide.md) and
+[Repository Layout](docs/repository-layout.md).
+
+This repository supports two audiences:
+
+- Instructors and curriculum development work on `0X-Guide`.
+- Students consume `main`.
+
+The same lesson/problem structure exists across branches, but the current file
+contents must differ by audience.
+
+## Branch Roles
+
+For branch workflow details, see
+[Branching And PR Workflow](docs/pr-workflow.md) and
+[Testing Branch Behavior](docs/testing-branch-behavior.md).
+
+### `0X-Guide`
+
+- Instructor source of truth.
+- Lesson problem files should have answers filled in.
+- Teaching/support material belongs here, including `teaching-notes/`,
+  `wip-problems/`, `base/`, and internal docs.
+- CI for PRs into this branch should run the real unit tests and expect them to
+  pass.
+- Feature/content branches for instructor work should branch from `0X-Guide`
+  and PR back into `0X-Guide`.
+
+### `dev`
+
+- Student-release staging branch.
+- Use this branch as the place to prepare a clean student version before merging
+  into `main`.
+- It may receive updates from `0X-Guide`, but the final state intended for
+  `main` must be stripped of answers and instructor-only material.
+- Keep `dev` close to what `main` will become after a release.
+
+### `main`
+
+- Student-facing release branch.
+- Current files must not include answers.
+- Current files must not include instructor-only folders such as
+  `teaching-notes/` or `wip-problems/`.
+- Tests should be pending/skipped or otherwise safe for starter-code files.
+- Do not merge answer-rich work directly into `main`.
+
+Historical answer commits are acceptable because `0X-Guide` is public. The
+important invariant is that the current tree of `main` is student-clean.
+
+## Release Flow
+
+For the release checklist and student/fork-specific testing expectations, see
+[Branching And PR Workflow](docs/pr-workflow.md) and
+[Testing Branch Behavior](docs/testing-branch-behavior.md).
+
+Use this mental model when moving curriculum updates toward students:
+
+1. Develop and verify full answers/content on `0X-Guide`.
+2. Bring the desired changes into `dev`.
+3. Strip answers and remove instructor-only files from `dev`.
+4. Ensure tests in the student version are pending/skipped where appropriate.
+5. PR `dev` into `main`.
+
+Before opening or approving a PR into `main`, check the current tree for:
+
+- Filled-in lesson answers.
+- Active tests that fail on blank starter code.
+- `teaching-notes/`, `wip-problems/`, or other instructor-only material.
+
+## Current Curriculum Context
+
+For current lesson organization context, see
+[Repository Layout](docs/repository-layout.md).
+
+At the time this file was created, answers for lessons 1, 2, 3, 5, 6, 9, and 10
+had been removed from `0X-Guide` by earlier merges and need restoration there.
+Lesson 4 had already been restored by issue/PR work around `CODE-139`.
+
+When restoring `0X-Guide`, prefer restoring answer-bearing lesson files from
+known good historical commits or branches, then running the relevant unit tests.
+Do not solve by making tests pending on `0X-Guide`; guide tests should prove the
+answer files are valid.
+
+## Tests And Scripts
+
+For testing structure and script ownership, see
+[Maintainer Guide](docs/maintainer-guide.md),
+[Repository Layout](docs/repository-layout.md), and
+[Testing Branch Behavior](docs/testing-branch-behavior.md).
+
+- `package.json` uses per-unit npm scripts such as `test:01`, `test:02`, etc.
+- Root test aliases delegate into the JS workspace. The JS workspace owns the
+  real Jest paths in `topics/js/package.json`.
+- `topics/js/jest.config.js` is the JS workspace Jest config and should stay
+  ESM. It points at `topics/js/jest.pathSequencer.js`.
+- `topics/js/jest.pathSequencer.js` sorts test files by normalized path with
+  numeric-aware ordering. Keep this in place so grouped lesson commands run and
+  report in lesson/file order.
+- `npm run test:jest` inside `topics/js` uses `--runInBand` for one-file-at-a-
+  time execution and the custom sequencer for deterministic file order. Do not
+  replace one with the other; they solve different problems.
+- Keep workflow matrix commands aligned with `package.json` script names.
+- In particular, workflows that call `npm run test:09` and `npm run test:10`
+  require `package.json` to define `test:09` and `test:10`, not `test-09` and
+  `test-10`.
+- Use Jest-compatible skip APIs such as `describe.skip`, `it.skip`, or
+  `test.skip` for intentionally pending student-safe tests. Do not reintroduce
+  Mocha-style pending behavior.
+- If local `node` or `npm` is unavailable in the shell, state that verification
+  could not be run locally and rely on static inspection or CI.
+
+## GitHub Actions Expectations
+
+For CI and branch-specific check expectations, see
+[Testing Branch Behavior](docs/testing-branch-behavior.md) and
+[Branching And PR Workflow](docs/pr-workflow.md).
+
+- PRs into `0X-Guide` should run all relevant guide tests and fail if answers
+  are missing or incorrect.
+- PRs into `main` should guard student-clean state. The current
+  `check:student-clean` script/workflow fails on top-level instructor-only
+  paths in the upstream repo while allowing student forks to keep personal notes
+  or class material.
+- Keep workflow changes narrowly scoped and avoid creating duplicate workflow
+  files that do the same job.
+
+## Working Guidelines
+
+For day-to-day branch and PR commands, see
+[Branching And PR Workflow](docs/pr-workflow.md). For beginner-friendly Git
+command examples, see [Git Basics](docs/git-basics.md).
+
+- Before editing, check the current branch and status with `git status -sb`.
+- Preserve user changes already present in the worktree.
+- Do not remove `teaching-notes/`, `wip-problems/`, or filled answers when
+  working on `0X-Guide` unless explicitly asked.
+- Do not add answers, teaching notes, or wip material to `main`.
+- When in doubt about audience, ask which branch target the work is for:
+  instructor/guide or student/release.

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -16,11 +16,14 @@ Student-facing setup and test instructions belong in the root [README.md](../REA
 
 The JS topic workspace owns the real test runner configuration and lesson paths:
 
-- `topics/js/jest.config.cjs`: Jest configuration for the JS workspace.
+- `topics/js/jest.config.js`: Jest configuration for the JS workspace.
+- `topics/js/jest.pathSequencer.js`: path-based Jest test ordering for the JS workspace.
 - `topics/js/package.json`: per-lesson and project test scripts.
 - root `package.json`: stable aliases such as `npm run test:04`, `npm run test:08-server`, and `npm run test:projects`.
 
 The shared JS runner is `npm run test:jest` inside `topics/js`. It runs Jest through Node's native ESM support, uses `--runInBand` to keep test files serial during the migration, and uses `--ci` so local script behavior matches GitHub Actions.
+
+Jest uses `topics/js/jest.pathSequencer.js` to sort test files by normalized path with numeric-aware ordering. This keeps multi-file lesson output in lesson/file order while `--runInBand` keeps execution one file at a time.
 
 Generated WIP problem tests come from `scripts/generateFiles.sh` and should use Jest globals and matchers, not Chai imports. If that script changes, generate a sample problem in a temporary directory and inspect the resulting test file before committing.
 

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -44,7 +44,7 @@ The topic workspace package should own the real filesystem paths, such as:
 ```json
 {
   "scripts": {
-    "test:jest": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config ./jest.config.cjs --runInBand --ci",
+    "test:jest": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config ./jest.config.js --runInBand --ci",
     "test:09": "npm run test:jest -- lessons/09-Recursion/tests",
     "test:projects": "npm run test:jest -- projects"
   }
@@ -53,7 +53,7 @@ The topic workspace package should own the real filesystem paths, such as:
 
 This keeps docs, CI, and muscle memory stable if topic internals move later.
 
-For the JS workspace, Jest configuration lives in `topics/js/jest.config.cjs`. The shared `test:jest` script owns the Jest invocation, native ESM flag, serial execution, and CI mode. Per-lesson scripts should pass only the lesson or project path into that shared runner.
+For the JS workspace, Jest configuration lives in `topics/js/jest.config.js`. The shared `test:jest` script owns the Jest invocation, native ESM flag, serial execution, and CI mode. Per-lesson scripts should pass only the lesson or project path into that shared runner.
 
 ## Adding Topics
 

--- a/topics/js/jest.config.js
+++ b/topics/js/jest.config.js
@@ -1,10 +1,11 @@
 // topics/js is an ESM workspace. Keep transforms disabled and run Jest through
 // `node --experimental-vm-modules` so tests execute the lesson files as native
 // ECMAScript modules during the migration.
-module.exports = {
+export default {
   clearMocks: true,
   restoreMocks: true,
   testEnvironment: "node",
   testMatch: ["<rootDir>/**/*.test.js"],
+  testSequencer: "<rootDir>/jest.pathSequencer.js",
   transform: {},
 };

--- a/topics/js/jest.pathSequencer.js
+++ b/topics/js/jest.pathSequencer.js
@@ -1,0 +1,19 @@
+import path from "node:path";
+import TestSequencer from "@jest/test-sequencer";
+
+const pathCollator = new Intl.Collator("en", {
+  numeric: true,
+  sensitivity: "base",
+});
+
+export default class PathSequencer extends TestSequencer {
+  sort(tests) {
+    return [...tests].sort((testA, testB) =>
+      pathCollator.compare(normalizeTestPath(testA), normalizeTestPath(testB)),
+    );
+  }
+}
+
+function normalizeTestPath(test) {
+  return path.relative(import.meta.dirname, test.path).split(path.sep).join("/");
+}

--- a/topics/js/package.json
+++ b/topics/js/package.json
@@ -6,7 +6,7 @@
   "description": "JavaScript lessons and projects for intro-to-code.",
   "scripts": {
     "test": "npm run test:01 && npm run test:02 && npm run test:03 && npm run test:04 && npm run test:05 && npm run test:06 && npm run test:07 && npm run test:08 && npm run test:08-server && npm run test:09 && npm run test:10 && npm run test:11 && npm run test:projects",
-    "test:jest": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config ./jest.config.cjs --runInBand --ci",
+    "test:jest": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config ./jest.config.js --runInBand --ci",
     "test:01": "npm run test:jest -- lessons/01-Values-and-Data-Types/01-valuesTypes.test.js",
     "test:02": "npm run test:jest -- lessons/02-Conditionals/tests",
     "test:03": "npm run test:jest -- lessons/03-Methods-and-Functions/tests",


### PR DESCRIPTION
## Summary

- Add a deterministic Jest test sequencer for the JS workspace.
- Sort test files by normalized path with numeric-aware ordering so grouped lesson commands report in lesson/file order.
- Convert the JS Jest config from CJS to ESM to match the repo's import/export teaching style.
- Update JS test scripts and maintainer docs to reference `jest.config.js`.
- Update `AGENTS.md` with links to supporting docs and notes about Jest config, sequencing, `--runInBand`, and skip APIs.

## Testing

- `node --check topics/js/jest.config.js`
  - Confirms the renamed ESM Jest config parses before Jest loads it.
- `node --check topics/js/jest.pathSequencer.js`
  - Confirms the new ESM sequencer parses before it is wired into Jest.
- `npm --workspace @intro-to-code/js run test:jest -- --listTests lessons/08-Async-Await-APIs/tests`
  - Verifies the sequencer lists lesson 08 tests in numeric path order without running the port-binding test suite.
- `npm run test:07`
  - Runs a multi-file lesson suite through the shared Jest script with the sequencer active.
- `npm run check:focused-tests`
  - Confirms no focused tests were introduced while changing test infrastructure/docs.

## Issues

Closes #187  
Parent: #173
